### PR TITLE
refactor(db)!: simplify attachment ownership

### DIFF
--- a/drizzle/0010_add-attachment-owner-columns.sql
+++ b/drizzle/0010_add-attachment-owner-columns.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "app"."durable_attachment" ADD COLUMN "ephemeral_attachment_id" bigint;--> statement-breakpoint
+ALTER TABLE "app"."ephemeral_attachment" ADD COLUMN "confession_internal_id" bigint;--> statement-breakpoint
+ALTER TABLE "app"."durable_attachment" ADD CONSTRAINT "durable_attachment_ephemeral_attachment_id_unique" UNIQUE("ephemeral_attachment_id");--> statement-breakpoint
+ALTER TABLE "app"."ephemeral_attachment" ADD CONSTRAINT "ephemeral_attachment_confession_internal_id_unique" UNIQUE("confession_internal_id");

--- a/drizzle/0011_backfill-attachment-foreign-keys.sql
+++ b/drizzle/0011_backfill-attachment-foreign-keys.sql
@@ -1,0 +1,32 @@
+-- Invert the old confession -> ephemeral attachment FK into the new ephemeral attachment -> confession FK.
+-- The old schema stored ownership on "confession"."attachment_id"; the new schema stores it on
+-- "ephemeral_attachment"."confession_internal_id".
+UPDATE "app"."ephemeral_attachment"
+SET "confession_internal_id" = "confession"."internal_id"
+FROM "app"."confession"
+WHERE "confession"."attachment_id" = "ephemeral_attachment"."id";
+
+-- Invert the old ephemeral attachment -> durable attachment FK into the new durable attachment -> ephemeral attachment FK.
+-- The old schema stored the durable upgrade link on "ephemeral_attachment"."durable_attachment_id";
+-- the new schema stores it on "durable_attachment"."ephemeral_attachment_id".
+UPDATE "app"."durable_attachment"
+SET "ephemeral_attachment_id" = "ephemeral_attachment"."id"
+FROM "app"."ephemeral_attachment"
+WHERE "ephemeral_attachment"."durable_attachment_id" = "durable_attachment"."id";
+
+-- Drop durable rows that were linked to ephemeral rows which no longer have an owning confession.
+-- These can be produced by rejected confessions under the old schema, where deleting the confession
+-- did not cascade to its attachment rows.
+DELETE FROM "app"."durable_attachment"
+USING "app"."ephemeral_attachment"
+WHERE "durable_attachment"."ephemeral_attachment_id" = "ephemeral_attachment"."id" AND "ephemeral_attachment"."confession_internal_id" IS NULL;
+
+-- Drop durable rows that were never linked from any ephemeral row in the old schema.
+-- There is no source ephemeral attachment to own them under the new model.
+DELETE FROM "app"."durable_attachment"
+WHERE "ephemeral_attachment_id" IS NULL;
+
+-- Drop ephemeral rows that were never linked from any confession in the old schema.
+-- There is no confession to own them under the new model.
+DELETE FROM "app"."ephemeral_attachment"
+WHERE "confession_internal_id" IS NULL;

--- a/drizzle/0012_migrate-attachment-ownership-model.sql
+++ b/drizzle/0012_migrate-attachment-ownership-model.sql
@@ -1,0 +1,12 @@
+ALTER TABLE "app"."ephemeral_attachment" DROP CONSTRAINT "ephemeral_attachment_durable_attachment_id_unique";--> statement-breakpoint
+ALTER TABLE "app"."confession" DROP CONSTRAINT "confession_attachment_id_ephemeral_attachment_id_fk";
+--> statement-breakpoint
+ALTER TABLE "app"."ephemeral_attachment" DROP CONSTRAINT "ephemeral_attachment_durable_attachment_id_durable_attachment_id_fk";
+--> statement-breakpoint
+DROP INDEX "app"."confession_to_attachment_unique_idx";--> statement-breakpoint
+ALTER TABLE "app"."durable_attachment" ALTER COLUMN "ephemeral_attachment_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "app"."ephemeral_attachment" ALTER COLUMN "confession_internal_id" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "app"."durable_attachment" ADD CONSTRAINT "durable_attachment_ephemeral_attachment_id_ephemeral_attachment_id_fk" FOREIGN KEY ("ephemeral_attachment_id") REFERENCES "app"."ephemeral_attachment"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app"."ephemeral_attachment" ADD CONSTRAINT "ephemeral_attachment_confession_internal_id_confession_internal_id_fk" FOREIGN KEY ("confession_internal_id") REFERENCES "app"."confession"("internal_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app"."confession" DROP COLUMN "attachment_id";--> statement-breakpoint
+ALTER TABLE "app"."ephemeral_attachment" DROP COLUMN "durable_attachment_id";

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,443 @@
+{
+  "id": "2d62c1eb-29b8-45f9-88b6-7b8e0f4c0575",
+  "prevId": "b3c44c2e-f066-4e33-87f8-e9ada8c0b0e7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.channel": {
+      "name": "channel",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_channel_id": {
+          "name": "log_channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "bit(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_approval_required": {
+          "name": "is_approval_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Confession'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_guild_id_guild_id_fk": {
+          "name": "channel_guild_id_guild_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "guild",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.confession": {
+      "name": "confession",
+      "schema": "app",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "confession_internal_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confession_id": {
+          "name": "confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "confession_to_channel_unique_idx": {
+          "name": "confession_to_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "confession_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confession_to_attachment_unique_idx": {
+          "name": "confession_to_attachment_unique_idx",
+          "columns": [
+            {
+              "expression": "confession_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "confession_channel_id_channel_id_fk": {
+          "name": "confession_channel_id_channel_id_fk",
+          "tableFrom": "confession",
+          "tableTo": "channel",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "confession_attachment_id_ephemeral_attachment_id_fk": {
+          "name": "confession_attachment_id_ephemeral_attachment_id_fk",
+          "tableFrom": "confession",
+          "tableTo": "ephemeral_attachment",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.durable_attachment": {
+      "name": "durable_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ephemeral_attachment_id": {
+          "name": "ephemeral_attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "durable_attachment_ephemeral_attachment_id_unique": {
+          "name": "durable_attachment_ephemeral_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ephemeral_attachment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ephemeral_attachment": {
+      "name": "ephemeral_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "confession_internal_id": {
+          "name": "confession_internal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_attachment_id": {
+          "name": "durable_attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ephemeral_attachment_durable_attachment_id_durable_attachment_id_fk": {
+          "name": "ephemeral_attachment_durable_attachment_id_durable_attachment_id_fk",
+          "tableFrom": "ephemeral_attachment",
+          "tableTo": "durable_attachment",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "durable_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ephemeral_attachment_confession_internal_id_unique": {
+          "name": "ephemeral_attachment_confession_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "confession_internal_id"
+          ]
+        },
+        "ephemeral_attachment_durable_attachment_id_unique": {
+          "name": "ephemeral_attachment_durable_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "durable_attachment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.guild": {
+      "name": "guild",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confession_id": {
+          "name": "last_confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app": "app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,443 @@
+{
+  "id": "c514cd1d-c4a7-4ef0-aa41-362d7dad04cd",
+  "prevId": "2d62c1eb-29b8-45f9-88b6-7b8e0f4c0575",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.channel": {
+      "name": "channel",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_channel_id": {
+          "name": "log_channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "bit(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_approval_required": {
+          "name": "is_approval_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Confession'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_guild_id_guild_id_fk": {
+          "name": "channel_guild_id_guild_id_fk",
+          "tableFrom": "channel",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "tableTo": "guild",
+          "schemaTo": "app",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.confession": {
+      "name": "confession",
+      "schema": "app",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "confession_internal_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "app",
+            "type": "always"
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confession_id": {
+          "name": "confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attachment_id": {
+          "name": "attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "confession_to_channel_unique_idx": {
+          "name": "confession_to_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "confession_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "confession_to_attachment_unique_idx": {
+          "name": "confession_to_attachment_unique_idx",
+          "columns": [
+            {
+              "expression": "confession_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "attachment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "confession_channel_id_channel_id_fk": {
+          "name": "confession_channel_id_channel_id_fk",
+          "tableFrom": "confession",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "tableTo": "channel",
+          "schemaTo": "app",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "confession_attachment_id_ephemeral_attachment_id_fk": {
+          "name": "confession_attachment_id_ephemeral_attachment_id_fk",
+          "tableFrom": "confession",
+          "columnsFrom": [
+            "attachment_id"
+          ],
+          "tableTo": "ephemeral_attachment",
+          "schemaTo": "app",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.durable_attachment": {
+      "name": "durable_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ephemeral_attachment_id": {
+          "name": "ephemeral_attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "durable_attachment_ephemeral_attachment_id_unique": {
+          "name": "durable_attachment_ephemeral_attachment_id_unique",
+          "columns": [
+            "ephemeral_attachment_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ephemeral_attachment": {
+      "name": "ephemeral_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "confession_internal_id": {
+          "name": "confession_internal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "durable_attachment_id": {
+          "name": "durable_attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ephemeral_attachment_durable_attachment_id_durable_attachment_id_fk": {
+          "name": "ephemeral_attachment_durable_attachment_id_durable_attachment_id_fk",
+          "tableFrom": "ephemeral_attachment",
+          "columnsFrom": [
+            "durable_attachment_id"
+          ],
+          "tableTo": "durable_attachment",
+          "schemaTo": "app",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ephemeral_attachment_confession_internal_id_unique": {
+          "name": "ephemeral_attachment_confession_internal_id_unique",
+          "columns": [
+            "confession_internal_id"
+          ],
+          "nullsNotDistinct": false
+        },
+        "ephemeral_attachment_durable_attachment_id_unique": {
+          "name": "ephemeral_attachment_durable_attachment_id_unique",
+          "columns": [
+            "durable_attachment_id"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.guild": {
+      "name": "guild",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confession_id": {
+          "name": "last_confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app": "app"
+  },
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,404 @@
+{
+  "id": "c9c56ce9-52eb-4c45-9ed8-51379f35b82c",
+  "prevId": "c514cd1d-c4a7-4ef0-aa41-362d7dad04cd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.channel": {
+      "name": "channel",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_channel_id": {
+          "name": "log_channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "bit(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_approval_required": {
+          "name": "is_approval_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Confession'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_guild_id_guild_id_fk": {
+          "name": "channel_guild_id_guild_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "guild",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.confession": {
+      "name": "confession",
+      "schema": "app",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "confession_internal_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confession_id": {
+          "name": "confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "confession_to_channel_unique_idx": {
+          "name": "confession_to_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "confession_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "confession_channel_id_channel_id_fk": {
+          "name": "confession_channel_id_channel_id_fk",
+          "tableFrom": "confession",
+          "tableTo": "channel",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.durable_attachment": {
+      "name": "durable_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ephemeral_attachment_id": {
+          "name": "ephemeral_attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "durable_attachment_ephemeral_attachment_id_ephemeral_attachment_id_fk": {
+          "name": "durable_attachment_ephemeral_attachment_id_ephemeral_attachment_id_fk",
+          "tableFrom": "durable_attachment",
+          "tableTo": "ephemeral_attachment",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "ephemeral_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "durable_attachment_ephemeral_attachment_id_unique": {
+          "name": "durable_attachment_ephemeral_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ephemeral_attachment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ephemeral_attachment": {
+      "name": "ephemeral_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "confession_internal_id": {
+          "name": "confession_internal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ephemeral_attachment_confession_internal_id_confession_internal_id_fk": {
+          "name": "ephemeral_attachment_confession_internal_id_confession_internal_id_fk",
+          "tableFrom": "ephemeral_attachment",
+          "tableTo": "confession",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "confession_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ephemeral_attachment_confession_internal_id_unique": {
+          "name": "ephemeral_attachment_confession_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "confession_internal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.guild": {
+      "name": "guild",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confession_id": {
+          "name": "last_confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {
+    "app": "app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1775999713116,
       "tag": "0009_durable-attachments",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777240842795,
+      "tag": "0010_add-attachment-owner-columns",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1777240842795,
       "tag": "0010_add-attachment-owner-columns",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777240891401,
+      "tag": "0011_backfill-attachment-foreign-keys",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777240891401,
       "tag": "0011_backfill-attachment-foreign-keys",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1777243866727,
+      "tag": "0012_migrate-attachment-ownership-model",
+      "breakpoints": true
     }
   ]
 }

--- a/src/ATTACHMENTS.md
+++ b/src/ATTACHMENTS.md
@@ -24,7 +24,7 @@ The active flow is:
 6. Discord returns a `Message` payload for the moderator log message.
 7. `process-confession-submission` attempts to extract durable attachment metadata from that returned message.
 8. When durable metadata is found, it is persisted in `durable_attachment`.
-9. When a durable row was persisted, `ephemeral_attachment.durable_attachment_id` is updated to point at it.
+9. The durable row points back to its source row through `durable_attachment.ephemeral_attachment_id`.
 10. If the confession is already approved, `process-confession-submission` posts the public confession using the durable attachment URL.
 11. If approval is required, the approval interaction later reads the durable attachment synchronously, queues `discord/confession.approve`, and returns an `UpdateMessage` response so Discord updates the moderator log message.
 12. Resend also reads from the durable attachment only; it does not redownload or reupload the file.
@@ -78,7 +78,7 @@ That separation exists for a reason:
 
 - `ephemeral_attachment` preserves the original modal-upload metadata exactly as received from Discord
 - `durable_attachment` records the later moderator-log-backed artifact that was created from it
-- `ephemeral_attachment.durable_attachment_id` explicitly encodes the lifecycle transition from
+- `durable_attachment.ephemeral_attachment_id` explicitly encodes the lifecycle transition from
   temporary upload to durable upload
 
 If the durable values were written back into `ephemeral_attachment` in place, the system would lose
@@ -95,16 +95,18 @@ invariants much easier to reason about.
 
 The relationship is:
 
-`ephemeral_attachment -> zero-or-one durable_attachment`
+```
+durable_attachment -> exactly-one ephemeral_attachment
+```
 
-This is encoded via `ephemeral_attachment.durable_attachment_id`.
+This is encoded via `durable_attachment.ephemeral_attachment_id`.
 
 Interpretation:
 
-- `NULL` means the modal upload has not been durably upgraded.
-- non-`NULL` means the modal upload has been upgraded and all later reads must use the durable row.
+- no durable row means the modal upload has not been durably upgraded.
+- a durable row means the modal upload has been upgraded and all later reads must use the durable row.
 
-This relationship is intentionally one-directional. The system models the fact that a modal upload is the original artifact and may later be upgraded to a durable artifact.
+This relationship is intentionally one-directional. The system models the fact that a durable artifact is created from one original modal upload.
 
 ## Workflow Invariants
 
@@ -149,7 +151,7 @@ The order of operations matters:
 
 1. create the moderator log message
 2. extract and persist the durable attachment
-3. link the durable attachment from the ephemeral row
+3. associate the durable row with the ephemeral row
 4. dispatch the public confession message
 
 This ordering ensures the public message never renders an attachment URL that was not durably persisted first.
@@ -264,9 +266,8 @@ Public confession messages remain simpler:
 7. Discord returns the created moderator log message.
 8. `process-confession-submission` first tries `message.attachments[0]` and falls back to
    `message.embeds[*].image` when the attachment array is empty or absent.
-9. `process-confession-submission` persists the durable row.
-10. `process-confession-submission` links `ephemeral_attachment.durable_attachment_id`.
-11. If approved, `process-confession-submission` posts the public confession using the durable URL.
+9. `process-confession-submission` persists the durable row linked by `durable_attachment.ephemeral_attachment_id`.
+10. If approved, `process-confession-submission` posts the public confession using the durable URL.
 
 ### Approval-required Confession with Attachment
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -73,12 +73,20 @@ export interface PersistableDurableAttachment {
   width: number | null;
 }
 
-async function insertAttachmentData(db: Interface, ephemeralAttachment: InsertableAttachment) {
+async function insertAttachmentData(
+  db: Interface,
+  confessionInternalId: bigint,
+  ephemeralAttachment: InsertableAttachment,
+) {
   return await tracer.asyncSpan('insert-attachment', async span => {
-    span.setAttribute('attachment.id', ephemeralAttachment.id);
+    span.setAttributes({
+      'attachment.id': ephemeralAttachment.id,
+      'confession.internal.id': confessionInternalId.toString(),
+    });
 
     const { rowCount } = await db.insert(schema.ephemeralAttachment).values({
       id: BigInt(ephemeralAttachment.id),
+      confessionInternalId,
       filename: ephemeralAttachment.filename,
       contentType: ephemeralAttachment.content_type,
       url: ephemeralAttachment.url,
@@ -120,6 +128,7 @@ export async function upsertDurableAttachmentData(
       .insert(schema.durableAttachment)
       .values({
         id: BigInt(durableAttachment.id),
+        ephemeralAttachmentId,
         messageId: BigInt(durableAttachment.messageId),
         channelId: BigInt(durableAttachment.channelId),
         filename: durableAttachment.filename,
@@ -130,8 +139,9 @@ export async function upsertDurableAttachmentData(
         width: durableAttachment.width,
       })
       .onConflictDoUpdate({
-        target: schema.durableAttachment.id,
+        target: schema.durableAttachment.ephemeralAttachmentId,
         set: {
+          id: sql`excluded.${sql.raw(schema.durableAttachment.id.name)}`,
           messageId: sql`excluded.${sql.raw(schema.durableAttachment.messageId.name)}`,
           channelId: sql`excluded.${sql.raw(schema.durableAttachment.channelId.name)}`,
           filename: sql`excluded.${sql.raw(schema.durableAttachment.filename.name)}`,
@@ -142,33 +152,6 @@ export async function upsertDurableAttachmentData(
           width: sql`excluded.${sql.raw(schema.durableAttachment.width.name)}`,
         },
       });
-  });
-}
-
-export async function linkDurableAttachmentData(
-  db: Interface,
-  ephemeralAttachmentId: bigint,
-  durableAttachmentId: bigint,
-) {
-  return await tracer.asyncSpan('link-durable-attachment', async span => {
-    span.setAttributes({
-      'attachment.id': ephemeralAttachmentId.toString(),
-      'durable.attachment.id': durableAttachmentId.toString(),
-    });
-
-    const { rowCount } = await db
-      .update(schema.ephemeralAttachment)
-      .set({ durableAttachmentId })
-      .where(eq(schema.ephemeralAttachment.id, ephemeralAttachmentId));
-
-    switch (rowCount) {
-      case null:
-        return UnexpectedRowCountDatabaseError.throwNew();
-      case 1:
-        return;
-      default:
-        return UnexpectedRowCountDatabaseError.throwNew(rowCount);
-    }
   });
 }
 
@@ -190,12 +173,6 @@ export async function insertConfession(
       'author.id': authorId.toString(),
     });
 
-    let attachmentId: bigint | null = null;
-    if (attachment !== null) {
-      attachmentId = BigInt(attachment.id);
-      await insertAttachmentData(db, attachment);
-    }
-
     const { confessionId } = await db
       .update(schema.guild)
       .set({ lastConfessionId: sql`${schema.guild.lastConfessionId} + 1` })
@@ -213,10 +190,11 @@ export async function insertConfession(
         content,
         approvedAt,
         parentMessageId,
-        attachmentId,
       })
       .returning({ internalId: schema.confession.internalId })
       .then(assertSingle);
+
+    if (attachment !== null) await insertAttachmentData(db, internalId, attachment);
 
     logger.debug('confession inserted', {
       'internal.id': internalId.toString(),
@@ -227,10 +205,7 @@ export async function insertConfession(
   });
 }
 
-/**
- * @throws {MissingRowCountDatabaseError}
- * @throws {UnexpectedRowCountDatabaseError}
- */
+/** @throws {UnexpectedRowCountDatabaseError} */
 export async function disableConfessionChannel(db: Interface, channelId: bigint, disabledAt: Date) {
   return await tracer.asyncSpan('disable-confession-channel', async span => {
     span.setAttributes({
@@ -258,10 +233,7 @@ export async function disableConfessionChannel(db: Interface, channelId: bigint,
   });
 }
 
-/**
- * @throws {MissingRowCountDatabaseError}
- * @throws {UnexpectedRowCountDatabaseError}
- */
+/** @throws {UnexpectedRowCountDatabaseError} */
 export async function resetLogChannel(db: Interface, channelId: bigint) {
   return await tracer.asyncSpan('reset-log-channel', async span => {
     span.setAttribute('channel.id', channelId.toString());

--- a/src/lib/server/database/models/index.ts
+++ b/src/lib/server/database/models/index.ts
@@ -42,6 +42,7 @@ export type NewChannel = typeof channel.$inferInsert;
 
 export const durableAttachment = app.table('durable_attachment', {
   id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
+  ephemeralAttachmentId: bigint('ephemeral_attachment_id', { mode: 'bigint' }).unique(),
   messageId: bigint('message_id', { mode: 'bigint' }).notNull(),
   channelId: bigint('channel_id', { mode: 'bigint' }).notNull(),
   filename: text('filename').notNull(),
@@ -57,6 +58,7 @@ export type NewDurableAttachmentData = typeof durableAttachment.$inferInsert;
 
 export const ephemeralAttachment = app.table('ephemeral_attachment', {
   id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
+  confessionInternalId: bigint('confession_internal_id', { mode: 'bigint' }).unique(),
   filename: text('filename').notNull(),
   contentType: text('content_type'),
   url: text('url').notNull(),
@@ -110,8 +112,19 @@ export const confessionRelations = relations(confession, ({ one }) => ({
 }));
 
 export const ephemeralAttachmentRelations = relations(ephemeralAttachment, ({ one }) => ({
+  confession: one(confession, {
+    fields: [ephemeralAttachment.confessionInternalId],
+    references: [confession.internalId],
+  }),
   durableAttachment: one(durableAttachment, {
     fields: [ephemeralAttachment.durableAttachmentId],
     references: [durableAttachment.id],
+  }),
+}));
+
+export const durableAttachmentRelations = relations(durableAttachment, ({ one }) => ({
+  ephemeralAttachment: one(ephemeralAttachment, {
+    fields: [durableAttachment.ephemeralAttachmentId],
+    references: [ephemeralAttachment.id],
   }),
 }));

--- a/src/lib/server/database/models/index.ts
+++ b/src/lib/server/database/models/index.ts
@@ -40,37 +40,6 @@ export const channel = app.table('channel', {
 export type Channel = typeof channel.$inferSelect;
 export type NewChannel = typeof channel.$inferInsert;
 
-export const durableAttachment = app.table('durable_attachment', {
-  id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
-  ephemeralAttachmentId: bigint('ephemeral_attachment_id', { mode: 'bigint' }).unique(),
-  messageId: bigint('message_id', { mode: 'bigint' }).notNull(),
-  channelId: bigint('channel_id', { mode: 'bigint' }).notNull(),
-  filename: text('filename').notNull(),
-  contentType: text('content_type'),
-  url: text('url').notNull(),
-  proxyUrl: text('proxy_url').notNull(),
-  height: integer('height'),
-  width: integer('width'),
-});
-
-export type DurableAttachmentData = typeof durableAttachment.$inferSelect;
-export type NewDurableAttachmentData = typeof durableAttachment.$inferInsert;
-
-export const ephemeralAttachment = app.table('ephemeral_attachment', {
-  id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
-  confessionInternalId: bigint('confession_internal_id', { mode: 'bigint' }).unique(),
-  filename: text('filename').notNull(),
-  contentType: text('content_type'),
-  url: text('url').notNull(),
-  proxyUrl: text('proxy_url').notNull(),
-  durableAttachmentId: bigint('durable_attachment_id', { mode: 'bigint' })
-    .references(() => durableAttachment.id)
-    .unique(),
-});
-
-export type EphemeralAttachmentData = typeof ephemeralAttachment.$inferSelect;
-export type NewEphemeralAttachmentData = typeof ephemeralAttachment.$inferInsert;
-
 export const confession = app.table(
   'confession',
   {
@@ -90,24 +59,54 @@ export const confession = app.table(
     approvedAt: timestamp('approved_at', { withTimezone: true }).defaultNow(),
     authorId: bigint('author_id', { mode: 'bigint' }).notNull(),
     content: text('content').notNull(),
-    attachmentId: bigint('attachment_id', { mode: 'bigint' }).references(
-      () => ephemeralAttachment.id,
-    ),
   },
-  ({ confessionId, channelId, attachmentId }) => [
+  ({ confessionId, channelId }) => [
     uniqueIndex('confession_to_channel_unique_idx').on(confessionId, channelId),
-    uniqueIndex('confession_to_attachment_unique_idx').on(confessionId, attachmentId),
   ],
 );
 
 export type Confession = typeof confession.$inferSelect;
 export type NewConfession = typeof confession.$inferInsert;
 
+export const ephemeralAttachment = app.table('ephemeral_attachment', {
+  id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
+  confessionInternalId: bigint('confession_internal_id', { mode: 'bigint' })
+    .notNull()
+    .references(() => confession.internalId, { onDelete: 'cascade' })
+    .unique(),
+  filename: text('filename').notNull(),
+  contentType: text('content_type'),
+  url: text('url').notNull(),
+  proxyUrl: text('proxy_url').notNull(),
+});
+
+export type EphemeralAttachment = typeof ephemeralAttachment.$inferSelect;
+export type NewEphemeralAttachment = typeof ephemeralAttachment.$inferInsert;
+
+export const durableAttachment = app.table('durable_attachment', {
+  id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
+  ephemeralAttachmentId: bigint('ephemeral_attachment_id', { mode: 'bigint' })
+    .notNull()
+    .references(() => ephemeralAttachment.id, { onDelete: 'cascade' })
+    .unique(),
+  messageId: bigint('message_id', { mode: 'bigint' }).notNull(),
+  channelId: bigint('channel_id', { mode: 'bigint' }).notNull(),
+  filename: text('filename').notNull(),
+  contentType: text('content_type'),
+  url: text('url').notNull(),
+  proxyUrl: text('proxy_url').notNull(),
+  height: integer('height'),
+  width: integer('width'),
+});
+
+export type DurableAttachment = typeof durableAttachment.$inferSelect;
+export type NewDurableAttachment = typeof durableAttachment.$inferInsert;
+
 export const confessionRelations = relations(confession, ({ one }) => ({
   channel: one(channel, { fields: [confession.channelId], references: [channel.id] }),
   attachment: one(ephemeralAttachment, {
-    fields: [confession.attachmentId],
-    references: [ephemeralAttachment.id],
+    fields: [confession.internalId],
+    references: [ephemeralAttachment.confessionInternalId],
   }),
 }));
 
@@ -117,8 +116,8 @@ export const ephemeralAttachmentRelations = relations(ephemeralAttachment, ({ on
     references: [confession.internalId],
   }),
   durableAttachment: one(durableAttachment, {
-    fields: [ephemeralAttachment.durableAttachmentId],
-    references: [durableAttachment.id],
+    fields: [ephemeralAttachment.id],
+    references: [durableAttachment.ephemeralAttachmentId],
   }),
 }));
 

--- a/src/lib/server/inngest/functions/dispatch-approval/index.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/index.ts
@@ -55,7 +55,7 @@ export const dispatchApproval = inngest.createFunction(
               channelLabel: schema.channel.label,
               channelColor: schema.channel.color,
               ephemeralAttachmentId: schema.ephemeralAttachment.id,
-              attachmentId: schema.durableAttachment.id,
+              durableAttachmentId: schema.durableAttachment.id,
               attachmentFilename: schema.durableAttachment.filename,
               attachmentContentType: schema.durableAttachment.contentType,
               attachmentUrl: schema.durableAttachment.url,
@@ -67,11 +67,11 @@ export const dispatchApproval = inngest.createFunction(
             .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
             .leftJoin(
               schema.ephemeralAttachment,
-              eq(schema.confession.attachmentId, schema.ephemeralAttachment.id),
+              eq(schema.confession.internalId, schema.ephemeralAttachment.confessionInternalId),
             )
             .leftJoin(
               schema.durableAttachment,
-              eq(schema.ephemeralAttachment.durableAttachmentId, schema.durableAttachment.id),
+              eq(schema.ephemeralAttachment.id, schema.durableAttachment.ephemeralAttachmentId),
             )
             .where(eq(schema.confession.internalId, BigInt(event.data.internalId)))
             .limit(1)
@@ -91,12 +91,12 @@ export const dispatchApproval = inngest.createFunction(
 
           let attachment: SerializedConfessionForDispatch['attachment'] = null;
           if (result.ephemeralAttachmentId !== null) {
-            assert(result.attachmentId !== null);
+            assert(result.durableAttachmentId !== null);
             assert(result.attachmentFilename !== null);
             assert(result.attachmentUrl !== null);
             assert(result.attachmentProxyUrl !== null);
             attachment = {
-              id: result.attachmentId.toString(),
+              id: result.durableAttachmentId.toString(),
               filename: result.attachmentFilename,
               contentType: result.attachmentContentType,
               url: result.attachmentUrl,

--- a/src/lib/server/inngest/functions/process-confession-resend/index.ts
+++ b/src/lib/server/inngest/functions/process-confession-resend/index.ts
@@ -72,7 +72,7 @@ export const processConfessionResend = inngest.createFunction(
               channelColor: schema.channel.color,
               channelLogChannelId: schema.channel.logChannelId,
               ephemeralAttachmentId: schema.ephemeralAttachment.id,
-              attachmentId: schema.durableAttachment.id,
+              durableAttachmentId: schema.durableAttachment.id,
               attachmentFilename: schema.durableAttachment.filename,
               attachmentContentType: schema.durableAttachment.contentType,
               attachmentUrl: schema.durableAttachment.url,
@@ -84,11 +84,11 @@ export const processConfessionResend = inngest.createFunction(
             .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
             .leftJoin(
               schema.ephemeralAttachment,
-              eq(schema.confession.attachmentId, schema.ephemeralAttachment.id),
+              eq(schema.confession.internalId, schema.ephemeralAttachment.confessionInternalId),
             )
             .leftJoin(
               schema.durableAttachment,
-              eq(schema.ephemeralAttachment.durableAttachmentId, schema.durableAttachment.id),
+              eq(schema.ephemeralAttachment.id, schema.durableAttachment.ephemeralAttachmentId),
             )
             .where(
               and(
@@ -109,7 +109,7 @@ export const processConfessionResend = inngest.createFunction(
             return 'You cannot resend confessions until a valid confession log channel has been configured.';
 
           if (result.ephemeralAttachmentId !== null) {
-            if (result.attachmentId === null)
+            if (result.durableAttachmentId === null)
               return `Confession #${confessionId} includes a legacy attachment that is no longer available in the Discord CDN, so it cannot be resent.`;
 
             const permission = BigInt(data.memberPermissions);
@@ -119,12 +119,12 @@ export const processConfessionResend = inngest.createFunction(
 
           let attachment: SerializedConfessionForResend['attachment'] = null;
           if (result.ephemeralAttachmentId !== null) {
-            assert(result.attachmentId !== null);
+            assert(result.durableAttachmentId !== null);
             assert(result.attachmentFilename !== null);
             assert(result.attachmentUrl !== null);
             assert(result.attachmentProxyUrl !== null);
             attachment = {
-              id: result.attachmentId.toString(),
+              id: result.durableAttachmentId.toString(),
               filename: result.attachmentFilename,
               contentType: result.attachmentContentType,
               url: result.attachmentUrl,

--- a/src/lib/server/inngest/functions/process-confession-submission/index.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/index.ts
@@ -14,7 +14,6 @@ import {
   db,
   type InsertableAttachment,
   insertConfession,
-  linkDurableAttachmentData,
   type PersistableDurableAttachment,
   resetLogChannel,
   type SerializedAttachment,
@@ -241,6 +240,7 @@ export const processConfessionSubmission = inngest.createFunction(
                 data.parentMessageId === null ? null : BigInt(data.parentMessageId),
                 attachment,
               ),
+            { isolationLevel: 'read committed' },
           );
 
           return {
@@ -577,14 +577,7 @@ export const processConfessionSubmission = inngest.createFunction(
             name: 'Persist Durable Attachment',
           },
           async () =>
-            await db.transaction(async tx => {
-              await upsertDurableAttachmentData(tx, BigInt(attachment.id), durableAttachment);
-              await linkDurableAttachmentData(
-                tx,
-                BigInt(attachment.id),
-                BigInt(durableAttachment.id),
-              );
-            }),
+            await upsertDurableAttachmentData(db, BigInt(attachment.id), durableAttachment),
         );
       }
 

--- a/src/routes/webhook/discord/interaction/approval.ts
+++ b/src/routes/webhook/discord/interaction/approval.ts
@@ -85,7 +85,7 @@ class AlreadyApprovedApprovalError extends ApprovalError {
 class MissingDurableAttachmentApprovalError extends ApprovalError {
   constructor() {
     super(
-      'This legacy confession includes an attachment that is no longer available in the Discord CDN, so it cannot be approved or rejected.',
+      'This legacy confession includes an attachment that is no longer available in the Discord CDN, so it cannot be approved.',
     );
     this.name = 'MissingDurableAttachmentApprovalError';
   }
@@ -138,79 +138,73 @@ async function submitVerdict(
 
     return await db.transaction(
       async tx => {
-        const { approvedAt, disabledAt, authorId, confessionId, label, content, attachmentId } =
-          await tracer.asyncSpan('select-confession-details', async span => {
-            span.setAttribute('confession.internal.id', internalId.toString());
+        const result = await tracer.asyncSpan('select-confession-details', async span => {
+          span.setAttribute('confession.internal.id', internalId.toString());
 
-            const [result, ...rest] = await tx
-              .select({
-                disabledAt: channel.disabledAt,
-                label: channel.label,
-                authorId: confession.authorId,
-                approvedAt: confession.approvedAt,
-                content: confession.content,
-                confessionId: confession.confessionId,
-                attachmentId: confession.attachmentId,
-              })
-              .from(confession)
-              .innerJoin(channel, eq(confession.channelId, channel.id))
-              .where(eq(confession.internalId, internalId))
-              .limit(1)
-              .for('update');
-            strictEqual(rest.length, 0);
-            assert(typeof result !== 'undefined');
+          const result = await tx
+            .select({
+              disabledAt: channel.disabledAt,
+              label: channel.label,
+              authorId: confession.authorId,
+              approvedAt: confession.approvedAt,
+              content: confession.content,
+              confessionId: confession.confessionId,
+              ephemeralAttachmentId: ephemeralAttachment.id,
+              durableAttachmentId: durableAttachment.id,
+              attachmentFilename: durableAttachment.filename,
+              attachmentContentType: durableAttachment.contentType,
+              attachmentUrl: durableAttachment.url,
+              attachmentHeight: durableAttachment.height,
+              attachmentWidth: durableAttachment.width,
+            })
+            .from(confession)
+            .innerJoin(channel, eq(confession.channelId, channel.id))
+            .leftJoin(
+              ephemeralAttachment,
+              eq(confession.internalId, ephemeralAttachment.confessionInternalId),
+            )
+            .leftJoin(
+              durableAttachment,
+              eq(ephemeralAttachment.id, durableAttachment.ephemeralAttachmentId),
+            )
+            .where(eq(confession.internalId, internalId))
+            .limit(1)
+            .for('update', { of: confession })
+            .then(assertSingle);
 
-            logger.debug('confession details fetched', {
-              'confession.id': result.confessionId.toString(),
-              label: result.label,
+          logger.debug('confession details fetched', {
+            'confession.id': result.confessionId.toString(),
+            label: result.label,
+          });
+
+          return result;
+        });
+        const { approvedAt, disabledAt, authorId, confessionId, label, content } = result;
+
+        let embedAttachment: EmbedAttachment | null = null;
+        if (result.ephemeralAttachmentId !== null)
+          if (result.durableAttachmentId === null) {
+            if (isApproved) MissingDurableAttachmentApprovalError.throwNew();
+            else
+              logger.warn('durable attachment missing for rejected confession', {
+                'attachment.id': result.ephemeralAttachmentId.toString(),
+              });
+          } else {
+            assert(result.attachmentFilename !== null);
+            assert(result.attachmentUrl !== null);
+            logger.debug('attachment fetched', {
+              'attachment.filename': result.attachmentFilename,
             });
 
-            return result;
-          });
-
-        // TODO: Refactor to Relations API once the `bigint` bug is fixed.
-        let embedAttachment: EmbedAttachment | null = null;
-        if (attachmentId !== null)
-          embedAttachment = await tracer.asyncSpan('select-attachment', async span => {
-            span.setAttribute('attachment.id', attachmentId.toString());
-
-            const retrieved = await tx
-              .select({
-                durableAttachmentId: durableAttachment.id,
-                filename: durableAttachment.filename,
-                contentType: durableAttachment.contentType,
-                url: durableAttachment.url,
-                height: durableAttachment.height,
-                width: durableAttachment.width,
-              })
-              .from(ephemeralAttachment)
-              .leftJoin(
-                durableAttachment,
-                eq(ephemeralAttachment.durableAttachmentId, durableAttachment.id),
-              )
-              .where(eq(ephemeralAttachment.id, attachmentId))
-              .then(assertSingle);
-
-            if (retrieved.durableAttachmentId === null) {
-              if (!isApproved) {
-                logger.warn('durable attachment missing for rejected confession', {
-                  'attachment.id': attachmentId.toString(),
-                });
-                return null;
-              }
-              MissingDurableAttachmentApprovalError.throwNew();
-            }
-
-            assert(retrieved.filename !== null);
-            assert(retrieved.url !== null);
-            logger.debug('attachment fetched', { 'attachment.filename': retrieved.filename });
-
-            const embed: EmbedAttachment = { filename: retrieved.filename, url: retrieved.url };
-            if (retrieved.contentType !== null) embed.content_type = retrieved.contentType;
-            if (retrieved.height !== null) embed.height = retrieved.height;
-            if (retrieved.width !== null) embed.width = retrieved.width;
-            return embed;
-          });
+            embedAttachment = {
+              filename: result.attachmentFilename,
+              url: result.attachmentUrl,
+            };
+            if (result.attachmentContentType !== null)
+              embedAttachment.content_type = result.attachmentContentType;
+            if (result.attachmentHeight !== null) embedAttachment.height = result.attachmentHeight;
+            if (result.attachmentWidth !== null) embedAttachment.width = result.attachmentWidth;
+          }
 
         if (disabledAt !== null && disabledAt <= timestamp)
           DisabledChannelConfessError.throwNew(disabledAt);


### PR DESCRIPTION
This refactor simplifies attachment ownership so confession cleanup now follows the database ownership chain instead of relying on nullable cross-links. Ephemeral attachment rows are owned by confessions, durable attachment rows are owned by ephemeral attachment rows, and rejection deletes now cascade through both attachment tables.

The migration is staged: first add nullable owner columns and uniqueness constraints, then use the custom backfill migration to invert the old foreign-key direction and clean up rows that cannot satisfy the new ownership graph, then finalize by enforcing non-null ownership, adding cascading foreign keys, and dropping the old columns.

## Implementation Notes

- Replaced `confession.attachment_id` with `ephemeral_attachment.confession_internal_id`.
- Replaced `ephemeral_attachment.durable_attachment_id` with `durable_attachment.ephemeral_attachment_id`.
- Backfilled the new owner columns by inverting the old relationships, then deleted orphan durable/ephemeral rows in the same custom data migration before the final `NOT NULL` constraints are applied.
- Updated submission, resend, approval dispatch, and moderation approval reads to use the new ownership direction.
- Simplified approval attachment loading into the locked confession read and scoped the lock to the confession row with `FOR UPDATE OF confession`.
- Removed the durable attachment linking helper because durable rows now directly reference their source ephemeral attachment.
- Updated `src/ATTACHMENTS.md` to document the new lifecycle and ownership model.

## Breaking Changes

This is a database-contract breaking change for anything that reads or writes attachment tables directly.

- `confession.attachment_id` is removed.
- `ephemeral_attachment.durable_attachment_id` is removed.
- New ownership columns are required after the final migration:
  - `ephemeral_attachment.confession_internal_id`
  - `durable_attachment.ephemeral_attachment_id`
- The custom backfill migration deletes orphan attachment rows before the final migration makes the new ownership columns non-null.

Reviewer caveats and limitations:

- Please closely and critically audit the custom backfill and cleanup migration. The cleanup should not destroy data that the old production handlers could realistically have produced as valid reachable data, even if the old nullable schema made additional impossible states theoretically representable.
- This does not introduce a generalized multi-attachment model yet. The new foreign keys are unique, so the current one-attachment-per-confession invariant remains.
- The durable attachment table still uses the Discord durable attachment snowflake as its primary key. A future migration can introduce separate internal `bigint` IDs before supporting multiple attachments.
- Orphan attachment rows are intentionally discarded during migration because they cannot be safely attached to a confession under the new ownership model.
- The migration guarantees every remaining ephemeral row has a confession owner and every remaining durable row has an ephemeral owner. It does not guarantee every confession-owned ephemeral row has durable metadata, so approval/resend still keep explicit missing-durable handling.
- Discord/Inngest event schemas are unchanged; the breaking surface is the database schema and internal database helper contract.

## Test Cases

- [ ] Approval rejects moderators without `Manage Messages`.
- [ ] Approval rejects disabled channels.
- [ ] Approval blocks already-approved confessions.
- [ ] Approval with durable attachment still includes attachment metadata.
- [ ] Approval with missing durable attachment returns the existing approval error path.
- [ ] Rejection with durable attachment includes attachment metadata.
- [ ] Rejection with missing durable attachment deletes the confession without attachment metadata.
- [ ] Rejection cascades confession deletion to ephemeral and durable attachment rows through database foreign keys.
- [ ] Resend reads durable attachment metadata through the new ownership joins.
- [ ] Approval dispatch reads durable attachment metadata through the new ownership joins.
