### PR TITLE
feat(thread): upsert anonymous thread replies

### DIFF
--- a/drizzle/0014_thread-reply-support.sql
+++ b/drizzle/0014_thread-reply-support.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "app"."pending_channel_thread_kind" ADD VALUE 'new-thread-reply';--> statement-breakpoint
+ALTER TABLE "app"."pending_channel_thread" ADD COLUMN "parent_message_id" bigint;--> statement-breakpoint
+CREATE UNIQUE INDEX "pending_channel_thread_reply_target_unique_idx" ON "app"."pending_channel_thread" USING btree ("channel_id","parent_message_id") WHERE "app"."pending_channel_thread"."parent_message_id" is not null;

--- a/drizzle/0015_thread-support-overhaul.sql
+++ b/drizzle/0015_thread-support-overhaul.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "app"."pending_channel_thread_title" (
+	"confession_internal_id" bigint PRIMARY KEY NOT NULL,
+	"pending_channel_thread_id" bigint NOT NULL,
+	"title" text NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "app"."approved_channel_thread" DROP CONSTRAINT "approved_channel_thread_pending_channel_thread_id_unique";--> statement-breakpoint
+ALTER TABLE "app"."approved_channel_thread" DROP CONSTRAINT "approved_channel_thread_pending_channel_thread_id_pending_channel_thread_id_fk";
+--> statement-breakpoint
+ALTER TABLE "app"."confession" DROP CONSTRAINT "confession_pending_channel_thread_id_pending_channel_thread_id_fk";
+--> statement-breakpoint
+DROP INDEX "app"."confession_pending_channel_thread_id_idx";--> statement-breakpoint
+ALTER TABLE "app"."approved_channel_thread" ADD COLUMN "confession_internal_id" bigint NOT NULL;--> statement-breakpoint
+ALTER TABLE "app"."pending_channel_thread_title" ADD CONSTRAINT "pending_channel_thread_title_confession_internal_id_confession_internal_id_fk" FOREIGN KEY ("confession_internal_id") REFERENCES "app"."confession"("internal_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app"."pending_channel_thread_title" ADD CONSTRAINT "pending_channel_thread_title_pending_channel_thread_id_pending_channel_thread_id_fk" FOREIGN KEY ("pending_channel_thread_id") REFERENCES "app"."pending_channel_thread"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "pending_channel_thread_title_pending_channel_thread_id_idx" ON "app"."pending_channel_thread_title" USING btree ("pending_channel_thread_id");--> statement-breakpoint
+ALTER TABLE "app"."approved_channel_thread" ADD CONSTRAINT "approved_channel_thread_confession_internal_id_pending_channel_thread_title_confession_internal_id_fk" FOREIGN KEY ("confession_internal_id") REFERENCES "app"."pending_channel_thread_title"("confession_internal_id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "channel_guild_id_idx" ON "app"."channel" USING btree ("guild_id");--> statement-breakpoint
+ALTER TABLE "app"."approved_channel_thread" DROP COLUMN "pending_channel_thread_id";--> statement-breakpoint
+ALTER TABLE "app"."confession" DROP COLUMN "pending_channel_thread_id";--> statement-breakpoint
+ALTER TABLE "app"."pending_channel_thread" DROP COLUMN "title";--> statement-breakpoint
+ALTER TABLE "app"."approved_channel_thread" ADD CONSTRAINT "approved_channel_thread_confession_internal_id_unique" UNIQUE("confession_internal_id");

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,634 @@
+{
+  "id": "ad99196a-a167-4c48-be51-8f33381597d1",
+  "prevId": "2d5aa168-6c3b-4fd3-ab09-bb173ffab0bd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.approved_channel_thread": {
+      "name": "approved_channel_thread",
+      "schema": "app",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pending_channel_thread_id": {
+          "name": "pending_channel_thread_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approved_channel_thread_pending_channel_thread_id_pending_channel_thread_id_fk": {
+          "name": "approved_channel_thread_pending_channel_thread_id_pending_channel_thread_id_fk",
+          "tableFrom": "approved_channel_thread",
+          "tableTo": "pending_channel_thread",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "pending_channel_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_channel_thread_pending_channel_thread_id_unique": {
+          "name": "approved_channel_thread_pending_channel_thread_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "pending_channel_thread_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.channel": {
+      "name": "channel",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_channel_id": {
+          "name": "log_channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "bit(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_approval_required": {
+          "name": "is_approval_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Confession'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "channel_guild_id_guild_id_fk": {
+          "name": "channel_guild_id_guild_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "guild",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.confession": {
+      "name": "confession",
+      "schema": "app",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "confession_internal_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pending_channel_thread_id": {
+          "name": "pending_channel_thread_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confession_id": {
+          "name": "confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "confession_channel_id_idx": {
+          "name": "confession_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confession_pending_channel_thread_id_idx": {
+          "name": "confession_pending_channel_thread_id_idx",
+          "columns": [
+            {
+              "expression": "pending_channel_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"app\".\"confession\".\"pending_channel_thread_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confession_to_channel_unique_idx": {
+          "name": "confession_to_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "confession_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "confession_channel_id_channel_id_fk": {
+          "name": "confession_channel_id_channel_id_fk",
+          "tableFrom": "confession",
+          "tableTo": "channel",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "confession_pending_channel_thread_id_pending_channel_thread_id_fk": {
+          "name": "confession_pending_channel_thread_id_pending_channel_thread_id_fk",
+          "tableFrom": "confession",
+          "tableTo": "pending_channel_thread",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "pending_channel_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.durable_attachment": {
+      "name": "durable_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ephemeral_attachment_id": {
+          "name": "ephemeral_attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "durable_attachment_ephemeral_attachment_id_ephemeral_attachment_id_fk": {
+          "name": "durable_attachment_ephemeral_attachment_id_ephemeral_attachment_id_fk",
+          "tableFrom": "durable_attachment",
+          "tableTo": "ephemeral_attachment",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "ephemeral_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "durable_attachment_ephemeral_attachment_id_unique": {
+          "name": "durable_attachment_ephemeral_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ephemeral_attachment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ephemeral_attachment": {
+      "name": "ephemeral_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "confession_internal_id": {
+          "name": "confession_internal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ephemeral_attachment_confession_internal_id_confession_internal_id_fk": {
+          "name": "ephemeral_attachment_confession_internal_id_confession_internal_id_fk",
+          "tableFrom": "ephemeral_attachment",
+          "tableTo": "confession",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "confession_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ephemeral_attachment_confession_internal_id_unique": {
+          "name": "ephemeral_attachment_confession_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "confession_internal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.guild": {
+      "name": "guild",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confession_id": {
+          "name": "last_confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.pending_channel_thread": {
+      "name": "pending_channel_thread",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "pending_channel_thread_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "kind": {
+          "name": "kind",
+          "type": "pending_channel_thread_kind",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_channel_thread_channel_id_idx": {
+          "name": "pending_channel_thread_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_channel_thread_reply_target_unique_idx": {
+          "name": "pending_channel_thread_reply_target_unique_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app\".\"pending_channel_thread\".\"parent_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_channel_thread_channel_id_channel_id_fk": {
+          "name": "pending_channel_thread_channel_id_channel_id_fk",
+          "tableFrom": "pending_channel_thread",
+          "tableTo": "channel",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "app.pending_channel_thread_kind": {
+      "name": "pending_channel_thread_kind",
+      "schema": "app",
+      "values": [
+        "new-thread",
+        "new-thread-reply"
+      ]
+    }
+  },
+  "schemas": {
+    "app": "app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,684 @@
+{
+  "id": "f6d631fe-fc3c-40a9-8f78-1d8897fef620",
+  "prevId": "ad99196a-a167-4c48-be51-8f33381597d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "app.approved_channel_thread": {
+      "name": "approved_channel_thread",
+      "schema": "app",
+      "columns": {
+        "thread_id": {
+          "name": "thread_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "confession_internal_id": {
+          "name": "confession_internal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "approved_channel_thread_confession_internal_id_pending_channel_thread_title_confession_internal_id_fk": {
+          "name": "approved_channel_thread_confession_internal_id_pending_channel_thread_title_confession_internal_id_fk",
+          "tableFrom": "approved_channel_thread",
+          "tableTo": "pending_channel_thread_title",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "confession_internal_id"
+          ],
+          "columnsTo": [
+            "confession_internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "approved_channel_thread_confession_internal_id_unique": {
+          "name": "approved_channel_thread_confession_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "confession_internal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.channel": {
+      "name": "channel",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "log_channel_id": {
+          "name": "log_channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disabled_at": {
+          "name": "disabled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color": {
+          "name": "color",
+          "type": "bit(24)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_approval_required": {
+          "name": "is_approval_required",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Confession'"
+        }
+      },
+      "indexes": {
+        "channel_guild_id_idx": {
+          "name": "channel_guild_id_idx",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_guild_id_guild_id_fk": {
+          "name": "channel_guild_id_guild_id_fk",
+          "tableFrom": "channel",
+          "tableTo": "guild",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "guild_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.confession": {
+      "name": "confession",
+      "schema": "app",
+      "columns": {
+        "internal_id": {
+          "name": "internal_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "confession_internal_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confession_id": {
+          "name": "confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "approved_at": {
+          "name": "approved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "confession_channel_id_idx": {
+          "name": "confession_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "confession_to_channel_unique_idx": {
+          "name": "confession_to_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "confession_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "confession_channel_id_channel_id_fk": {
+          "name": "confession_channel_id_channel_id_fk",
+          "tableFrom": "confession",
+          "tableTo": "channel",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.durable_attachment": {
+      "name": "durable_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "ephemeral_attachment_id": {
+          "name": "ephemeral_attachment_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "durable_attachment_ephemeral_attachment_id_ephemeral_attachment_id_fk": {
+          "name": "durable_attachment_ephemeral_attachment_id_ephemeral_attachment_id_fk",
+          "tableFrom": "durable_attachment",
+          "tableTo": "ephemeral_attachment",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "ephemeral_attachment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "durable_attachment_ephemeral_attachment_id_unique": {
+          "name": "durable_attachment_ephemeral_attachment_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "ephemeral_attachment_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.ephemeral_attachment": {
+      "name": "ephemeral_attachment",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "confession_internal_id": {
+          "name": "confession_internal_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proxy_url": {
+          "name": "proxy_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "ephemeral_attachment_confession_internal_id_confession_internal_id_fk": {
+          "name": "ephemeral_attachment_confession_internal_id_confession_internal_id_fk",
+          "tableFrom": "ephemeral_attachment",
+          "tableTo": "confession",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "confession_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "ephemeral_attachment_confession_internal_id_unique": {
+          "name": "ephemeral_attachment_confession_internal_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "confession_internal_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.guild": {
+      "name": "guild",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_confession_id": {
+          "name": "last_confession_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.pending_channel_thread": {
+      "name": "pending_channel_thread",
+      "schema": "app",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "pending_channel_thread_id_seq",
+            "schema": "app",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "pending_channel_thread_kind",
+          "typeSchema": "app",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_channel_thread_channel_id_idx": {
+          "name": "pending_channel_thread_channel_id_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_channel_thread_reply_target_unique_idx": {
+          "name": "pending_channel_thread_reply_target_unique_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "parent_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"app\".\"pending_channel_thread\".\"parent_message_id\" is not null",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_channel_thread_channel_id_channel_id_fk": {
+          "name": "pending_channel_thread_channel_id_channel_id_fk",
+          "tableFrom": "pending_channel_thread",
+          "tableTo": "channel",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "app.pending_channel_thread_title": {
+      "name": "pending_channel_thread_title",
+      "schema": "app",
+      "columns": {
+        "confession_internal_id": {
+          "name": "confession_internal_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "pending_channel_thread_id": {
+          "name": "pending_channel_thread_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "pending_channel_thread_title_pending_channel_thread_id_idx": {
+          "name": "pending_channel_thread_title_pending_channel_thread_id_idx",
+          "columns": [
+            {
+              "expression": "pending_channel_thread_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_channel_thread_title_confession_internal_id_confession_internal_id_fk": {
+          "name": "pending_channel_thread_title_confession_internal_id_confession_internal_id_fk",
+          "tableFrom": "pending_channel_thread_title",
+          "tableTo": "confession",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "confession_internal_id"
+          ],
+          "columnsTo": [
+            "internal_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pending_channel_thread_title_pending_channel_thread_id_pending_channel_thread_id_fk": {
+          "name": "pending_channel_thread_title_pending_channel_thread_id_pending_channel_thread_id_fk",
+          "tableFrom": "pending_channel_thread_title",
+          "tableTo": "pending_channel_thread",
+          "schemaTo": "app",
+          "columnsFrom": [
+            "pending_channel_thread_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "app.pending_channel_thread_kind": {
+      "name": "pending_channel_thread_kind",
+      "schema": "app",
+      "values": [
+        "new-thread",
+        "new-thread-reply"
+      ]
+    }
+  },
+  "schemas": {
+    "app": "app"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1778919101610,
       "tag": "0014_thread-reply-support",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1778927018607,
+      "tag": "0015_thread-support-overhaul",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1778128583068,
       "tag": "0013_anonymous-thread-support",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1778919101610,
+      "tag": "0014_thread-reply-support",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/server/confession/index.test.ts
+++ b/src/lib/server/confession/index.test.ts
@@ -124,6 +124,11 @@ describe('createLogPayload', () => {
           'https://discord.com/channels/100000000000000004/100000000000000001/100000000000000005',
         inline: true,
       },
+      {
+        name: 'Thread Title',
+        value: 'A thread title',
+        inline: true,
+      },
     ]);
   });
 
@@ -158,6 +163,11 @@ describe('createLogPayload', () => {
       {
         name: 'Thread Channel',
         value: '<#100000000000000002>',
+        inline: true,
+      },
+      {
+        name: 'Thread Title',
+        value: 'A thread title',
         inline: true,
       },
     ]);

--- a/src/lib/server/confession/index.test.ts
+++ b/src/lib/server/confession/index.test.ts
@@ -121,7 +121,7 @@ describe('createLogPayload', () => {
       {
         name: 'Reply To',
         value:
-          'https://discord.com/channels/100000000000000004/100000000000000002/100000000000000005',
+          'https://discord.com/channels/100000000000000004/100000000000000001/100000000000000005',
         inline: true,
       },
     ]);

--- a/src/lib/server/confession/index.test.ts
+++ b/src/lib/server/confession/index.test.ts
@@ -23,6 +23,7 @@ const confession = {
 const logConfession = {
   ...confession,
   channelId: '100000000000000001',
+  pendingThreadTitle: null,
   publishChannelId: '100000000000000002',
   authorId: '100000000000000003',
   channel: {
@@ -168,6 +169,41 @@ describe('createLogPayload', () => {
       {
         name: 'Thread Title',
         value: 'A thread title',
+        inline: true,
+      },
+    ]);
+  });
+
+  it('orders pending thread log fields before the Discord thread exists', () => {
+    const payload = createLogPayload(
+      {
+        ...logConfession,
+        parentMessageId: '100000000000000005',
+        pendingThreadTitle: 'A pending thread title',
+      },
+      { type: LogPayloadType.Pending, internalId: 100000000000000007n },
+    );
+
+    expect(payload.embeds?.[0]?.fields).toEqual([
+      {
+        name: 'Authored by',
+        value: '||<@100000000000000003>||',
+        inline: true,
+      },
+      {
+        name: 'Thread Channel',
+        value: '<#100000000000000002>',
+        inline: true,
+      },
+      {
+        name: 'Reply To',
+        value:
+          'https://discord.com/channels/100000000000000004/100000000000000001/100000000000000005',
+        inline: true,
+      },
+      {
+        name: 'Thread Title',
+        value: 'A pending thread title',
         inline: true,
       },
     ]);

--- a/src/lib/server/confession/index.ts
+++ b/src/lib/server/confession/index.ts
@@ -240,25 +240,29 @@ type DeserializableAttachment = Pick<
   'contentType' | 'filename' | 'height' | 'id' | 'url' | 'width'
 >;
 
+interface ConfessionPayloadInputChannel {
+  label: string;
+  color: string | null;
+}
+
 interface ConfessionPayloadInput {
   confessionId: string;
   content: string;
   createdAt: string;
   parentMessageId: string | null;
-  channel: {
-    label: string;
-    color: string | null;
-  };
+  channel: ConfessionPayloadInputChannel;
   attachment: DeserializableAttachment | null;
+}
+
+interface LogPayloadInputChannel extends ConfessionPayloadInputChannel {
+  guildId: string;
 }
 
 interface LogPayloadInput extends ConfessionPayloadInput {
   channelId: string;
   publishChannelId: string;
   authorId: string;
-  channel: ConfessionPayloadInput['channel'] & {
-    guildId: string;
-  };
+  channel: LogPayloadInputChannel;
   thread: {
     id: string;
     title: string;
@@ -348,7 +352,7 @@ export function createLogPayload(
   if (confession.parentMessageId !== null)
     fields.push({
       name: 'Reply To',
-      value: `https://discord.com/channels/${confession.channel.guildId}/${confession.publishChannelId}/${confession.parentMessageId}`,
+      value: `https://discord.com/channels/${confession.channel.guildId}/${confession.channelId}/${confession.parentMessageId}`,
       inline: true,
     });
 

--- a/src/lib/server/confession/index.ts
+++ b/src/lib/server/confession/index.ts
@@ -356,6 +356,9 @@ export function createLogPayload(
       inline: true,
     });
 
+  if (confession.thread !== null)
+    fields.push({ name: 'Thread Title', value: confession.thread.title, inline: true });
+
   // eslint-disable-next-line @typescript-eslint/init-declarations
   let image: EmbedImage | undefined;
   if (

--- a/src/lib/server/confession/index.ts
+++ b/src/lib/server/confession/index.ts
@@ -260,6 +260,7 @@ interface LogPayloadInputChannel extends ConfessionPayloadInputChannel {
 
 interface LogPayloadInput extends ConfessionPayloadInput {
   channelId: string;
+  pendingThreadTitle: string | null;
   publishChannelId: string;
   authorId: string;
   channel: LogPayloadInputChannel;
@@ -356,8 +357,8 @@ export function createLogPayload(
       inline: true,
     });
 
-  if (confession.thread !== null)
-    fields.push({ name: 'Thread Title', value: confession.thread.title, inline: true });
+  const threadTitle = confession.thread?.title ?? confession.pendingThreadTitle;
+  if (threadTitle !== null) fields.push({ name: 'Thread Title', value: threadTitle, inline: true });
 
   // eslint-disable-next-line @typescript-eslint/init-declarations
   let image: EmbedImage | undefined;

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -1,12 +1,12 @@
 import process from 'node:process';
 
+import { aliasedTable, and, eq, sql } from 'drizzle-orm';
 import { drizzle as neonDrizzle } from 'drizzle-orm/neon-serverless';
 import { drizzle as pgDrizzle } from 'drizzle-orm/node-postgres';
-import { eq, sql } from 'drizzle-orm';
 import { Pool as NeonPool } from '@neondatabase/serverless';
 import { Pool as PgPool } from 'pg';
 
-import { assertOptional, assertSingle, UnreachableCodeError } from '$lib/assert';
+import { AssertionError, assertSingle, UnreachableCodeError } from '$lib/assert';
 import type { Attachment } from '$lib/server/models/discord/attachment';
 import { Logger } from '$lib/server/telemetry/logger';
 import { normalizeDiscordAttachmentUrl } from '$lib/url/discord';
@@ -62,6 +62,33 @@ export type InsertableAttachment = Pick<
   'id' | 'filename' | 'content_type' | 'url' | 'proxy_url'
 >;
 
+interface FlatApprovedChannelThreadResolutionRow {
+  pendingChannelThreadId: bigint;
+  pendingApprovalTitleConfessionInternalId: bigint | null;
+  pendingApprovalThreadId: bigint | null;
+  threadApprovalPendingChannelThreadId: bigint | null;
+  threadApprovalTitleConfessionInternalId: bigint | null;
+  threadApprovalThreadId: bigint | null;
+}
+
+interface ResolvedApprovedChannelThread {
+  pendingChannelThreadId: bigint;
+  pendingChannelThreadTitleConfessionInternalId: bigint;
+  threadId: bigint;
+}
+
+interface ApprovedChannelThreadResolution {
+  pendingChannelThreadId: bigint;
+  approvedForPending: ResolvedApprovedChannelThread | null;
+  approvedForThread: ResolvedApprovedChannelThread | null;
+}
+
+interface NullableResolvedApprovedChannelThreadRow {
+  pendingChannelThreadId: bigint | null;
+  pendingChannelThreadTitleConfessionInternalId: bigint | null;
+  threadId: bigint | null;
+}
+
 export interface PersistableDurableAttachment {
   id: string;
   messageId: string;
@@ -72,6 +99,61 @@ export interface PersistableDurableAttachment {
   proxyUrl: string;
   height: number | null;
   width: number | null;
+}
+
+function createResolvedApprovedChannelThread(
+  row: NullableResolvedApprovedChannelThreadRow,
+  expectedPendingChannelThreadId: bigint | null,
+) {
+  if (row.threadId === null) {
+    if (row.pendingChannelThreadId !== null)
+      AssertionError.throwNew('invalid approved channel thread row: pending owner without thread');
+    if (row.pendingChannelThreadTitleConfessionInternalId !== null)
+      AssertionError.throwNew('invalid approved channel thread row: title owner without thread');
+    return null;
+  }
+
+  if (row.pendingChannelThreadId === null)
+    AssertionError.throwNew('invalid approved channel thread row: pending owner missing');
+  if (
+    expectedPendingChannelThreadId !== null &&
+    row.pendingChannelThreadId !== expectedPendingChannelThreadId
+  )
+    AssertionError.throwNew('invalid approved channel thread row: pending owner mismatch');
+  if (row.pendingChannelThreadTitleConfessionInternalId === null)
+    AssertionError.throwNew('invalid approved channel thread row: title owner missing');
+
+  return {
+    pendingChannelThreadId: row.pendingChannelThreadId,
+    pendingChannelThreadTitleConfessionInternalId:
+      row.pendingChannelThreadTitleConfessionInternalId,
+    threadId: row.threadId,
+  };
+}
+
+function createApprovedChannelThreadResolution(
+  row: FlatApprovedChannelThreadResolutionRow,
+): ApprovedChannelThreadResolution {
+  return {
+    pendingChannelThreadId: row.pendingChannelThreadId,
+    approvedForPending: createResolvedApprovedChannelThread(
+      {
+        pendingChannelThreadId:
+          row.pendingApprovalThreadId === null ? null : row.pendingChannelThreadId,
+        pendingChannelThreadTitleConfessionInternalId: row.pendingApprovalTitleConfessionInternalId,
+        threadId: row.pendingApprovalThreadId,
+      },
+      row.pendingChannelThreadId,
+    ),
+    approvedForThread: createResolvedApprovedChannelThread(
+      {
+        pendingChannelThreadId: row.threadApprovalPendingChannelThreadId,
+        pendingChannelThreadTitleConfessionInternalId: row.threadApprovalTitleConfessionInternalId,
+        threadId: row.threadApprovalThreadId,
+      },
+      row.pendingChannelThreadId,
+    ),
+  };
 }
 
 async function insertAttachmentData(
@@ -200,63 +282,137 @@ export async function insertConfession(
   });
 }
 
-async function loadApprovedThreadByPendingChannelThreadId(
+async function loadApprovedChannelThreadResolution(
   db: Interface,
-  pendingChannelThreadId: bigint,
+  pendingChannelThreadTitleConfessionInternalId: bigint,
+  threadId: bigint,
 ) {
-  return await tracer.asyncSpan('load-approved-thread-by-pending-channel-thread-id', async span => {
-    span.setAttribute('pending.channel.thread.id', pendingChannelThreadId.toString());
-    return await db
-      .select({
-        pendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
-        threadId: schema.approvedChannelThread.threadId,
-      })
-      .from(schema.approvedChannelThread)
-      .where(eq(schema.approvedChannelThread.pendingChannelThreadId, pendingChannelThreadId))
-      .limit(1)
-      .then(assertOptional);
-  });
-}
+  return await tracer.asyncSpan('load-approved-channel-thread-resolution', async span => {
+    span.setAttributes({
+      'pending.channel.thread.title.confession.internal.id':
+        pendingChannelThreadTitleConfessionInternalId.toString(),
+      'thread.id': threadId.toString(),
+    });
 
-async function loadApprovedThreadByThreadId(db: Interface, threadId: bigint) {
-  return await tracer.asyncSpan('load-approved-thread-by-thread-id', async span => {
-    span.setAttribute('thread.id', threadId.toString());
-    return await db
+    const approvedTitle = aliasedTable(schema.pendingChannelThreadTitle, 'approved_title');
+    const approvedThreadForPending = db
       .select({
-        pendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        pendingChannelThreadId: approvedTitle.pendingChannelThreadId,
+        pendingChannelThreadTitleConfessionInternalId:
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
         threadId: schema.approvedChannelThread.threadId,
       })
       .from(schema.approvedChannelThread)
+      .innerJoin(
+        approvedTitle,
+        eq(
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          approvedTitle.confessionInternalId,
+        ),
+      )
+      .as('approved_thread_for_pending');
+
+    const approvedThreadTitle = aliasedTable(
+      schema.pendingChannelThreadTitle,
+      'approved_thread_title',
+    );
+    const approvedThreadForThread = db
+      .select({
+        pendingChannelThreadId: approvedThreadTitle.pendingChannelThreadId,
+        pendingChannelThreadTitleConfessionInternalId:
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+        threadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.approvedChannelThread)
+      .innerJoin(
+        approvedThreadTitle,
+        eq(
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          approvedThreadTitle.confessionInternalId,
+        ),
+      )
       .where(eq(schema.approvedChannelThread.threadId, threadId))
+      .as('approved_thread_for_thread');
+
+    const row = await db
+      .select({
+        pendingChannelThreadId: schema.pendingChannelThreadTitle.pendingChannelThreadId,
+        pendingApprovalTitleConfessionInternalId:
+          approvedThreadForPending.pendingChannelThreadTitleConfessionInternalId,
+        pendingApprovalThreadId: approvedThreadForPending.threadId,
+        threadApprovalPendingChannelThreadId: approvedThreadForThread.pendingChannelThreadId,
+        threadApprovalTitleConfessionInternalId:
+          approvedThreadForThread.pendingChannelThreadTitleConfessionInternalId,
+        threadApprovalThreadId: approvedThreadForThread.threadId,
+      })
+      .from(schema.pendingChannelThreadTitle)
+      .leftJoin(
+        approvedThreadForPending,
+        eq(
+          schema.pendingChannelThreadTitle.pendingChannelThreadId,
+          approvedThreadForPending.pendingChannelThreadId,
+        ),
+      )
+      .leftJoin(
+        approvedThreadForThread,
+        and(
+          eq(
+            schema.pendingChannelThreadTitle.pendingChannelThreadId,
+            approvedThreadForThread.pendingChannelThreadId,
+          ),
+          eq(approvedThreadForThread.threadId, threadId),
+        ),
+      )
+      .where(
+        eq(
+          schema.pendingChannelThreadTitle.confessionInternalId,
+          pendingChannelThreadTitleConfessionInternalId,
+        ),
+      )
       .limit(1)
-      .then(assertOptional);
+      .then(assertSingle);
+
+    return createApprovedChannelThreadResolution(row);
   });
 }
 
 export async function resolveApprovedChannelThread(
   db: Transaction,
-  pendingChannelThreadId: bigint,
   threadId: bigint,
+  pendingChannelThreadTitleConfessionInternalId: bigint,
 ) {
   return await tracer.asyncSpan('resolve-approved-channel-thread', async span => {
     span.setAttributes({
-      'pending.channel.thread.id': pendingChannelThreadId.toString(),
+      'pending.channel.thread.title.confession.internal.id':
+        pendingChannelThreadTitleConfessionInternalId.toString(),
       'thread.id': threadId.toString(),
     });
 
-    await db.execute(sql`select pg_advisory_xact_lock(${threadId})`);
-
-    const approvedForPending = await loadApprovedThreadByPendingChannelThreadId(
+    const resolution = await loadApprovedChannelThreadResolution(
       db,
-      pendingChannelThreadId,
+      pendingChannelThreadTitleConfessionInternalId,
+      threadId,
     );
-    if (typeof approvedForPending !== 'undefined') return approvedForPending;
+    const { pendingChannelThreadId } = resolution;
+    span.setAttribute('pending.channel.thread.id', pendingChannelThreadId.toString());
 
-    const approvedForThread = await loadApprovedThreadByThreadId(db, threadId);
-    if (typeof approvedForThread !== 'undefined') return approvedForThread;
+    if (resolution.approvedForPending !== null) return resolution.approvedForPending;
+
+    await db.execute(sql`select pg_advisory_xact_lock(${pendingChannelThreadId})`);
+
+    const resolutionAfterLock = await loadApprovedChannelThreadResolution(
+      db,
+      pendingChannelThreadTitleConfessionInternalId,
+      threadId,
+    );
+    if (resolutionAfterLock.approvedForPending !== null)
+      return resolutionAfterLock.approvedForPending;
+
+    if (resolutionAfterLock.approvedForThread !== null)
+      return resolutionAfterLock.approvedForThread;
 
     const { rowCount } = await db.insert(schema.approvedChannelThread).values({
-      pendingChannelThreadId,
+      pendingChannelThreadTitleConfessionInternalId,
       threadId,
     });
 
@@ -265,7 +421,11 @@ export async function resolveApprovedChannelThread(
         return UnexpectedRowCountDatabaseError.throwNew();
       case 1:
         logger.debug('approved channel thread inserted');
-        return { pendingChannelThreadId, threadId };
+        return {
+          pendingChannelThreadId,
+          pendingChannelThreadTitleConfessionInternalId,
+          threadId,
+        };
       default:
         return UnexpectedRowCountDatabaseError.throwNew(rowCount);
     }

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -6,7 +6,7 @@ import { eq, sql } from 'drizzle-orm';
 import { Pool as NeonPool } from '@neondatabase/serverless';
 import { Pool as PgPool } from 'pg';
 
-import { assertSingle, UnreachableCodeError } from '$lib/assert';
+import { assertOptional, assertSingle, UnreachableCodeError } from '$lib/assert';
 import type { Attachment } from '$lib/server/models/discord/attachment';
 import { Logger } from '$lib/server/telemetry/logger';
 import { normalizeDiscordAttachmentUrl } from '$lib/url/discord';
@@ -197,6 +197,78 @@ export async function insertConfession(
     });
 
     return { internalId, confessionId };
+  });
+}
+
+async function loadApprovedThreadByPendingChannelThreadId(
+  db: Interface,
+  pendingChannelThreadId: bigint,
+) {
+  return await tracer.asyncSpan('load-approved-thread-by-pending-channel-thread-id', async span => {
+    span.setAttribute('pending.channel.thread.id', pendingChannelThreadId.toString());
+    return await db
+      .select({
+        pendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        threadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.approvedChannelThread)
+      .where(eq(schema.approvedChannelThread.pendingChannelThreadId, pendingChannelThreadId))
+      .limit(1)
+      .then(assertOptional);
+  });
+}
+
+async function loadApprovedThreadByThreadId(db: Interface, threadId: bigint) {
+  return await tracer.asyncSpan('load-approved-thread-by-thread-id', async span => {
+    span.setAttribute('thread.id', threadId.toString());
+    return await db
+      .select({
+        pendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        threadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.approvedChannelThread)
+      .where(eq(schema.approvedChannelThread.threadId, threadId))
+      .limit(1)
+      .then(assertOptional);
+  });
+}
+
+export async function resolveApprovedChannelThread(
+  db: Transaction,
+  pendingChannelThreadId: bigint,
+  threadId: bigint,
+) {
+  return await tracer.asyncSpan('resolve-approved-channel-thread', async span => {
+    span.setAttributes({
+      'pending.channel.thread.id': pendingChannelThreadId.toString(),
+      'thread.id': threadId.toString(),
+    });
+
+    await db.execute(sql`select pg_advisory_xact_lock(${threadId})`);
+
+    const approvedForPending = await loadApprovedThreadByPendingChannelThreadId(
+      db,
+      pendingChannelThreadId,
+    );
+    if (typeof approvedForPending !== 'undefined') return approvedForPending;
+
+    const approvedForThread = await loadApprovedThreadByThreadId(db, threadId);
+    if (typeof approvedForThread !== 'undefined') return approvedForThread;
+
+    const { rowCount } = await db.insert(schema.approvedChannelThread).values({
+      pendingChannelThreadId,
+      threadId,
+    });
+
+    switch (rowCount) {
+      case null:
+        return UnexpectedRowCountDatabaseError.throwNew();
+      case 1:
+        logger.debug('approved channel thread inserted');
+        return { pendingChannelThreadId, threadId };
+      default:
+        return UnexpectedRowCountDatabaseError.throwNew(rowCount);
+    }
   });
 }
 

--- a/src/lib/server/database/index.ts
+++ b/src/lib/server/database/index.ts
@@ -73,7 +73,7 @@ interface FlatApprovedChannelThreadResolutionRow {
 
 interface ResolvedApprovedChannelThread {
   pendingChannelThreadId: bigint;
-  pendingChannelThreadTitleConfessionInternalId: bigint;
+  confessionInternalId: bigint;
   threadId: bigint;
 }
 
@@ -85,7 +85,7 @@ interface ApprovedChannelThreadResolution {
 
 interface NullableResolvedApprovedChannelThreadRow {
   pendingChannelThreadId: bigint | null;
-  pendingChannelThreadTitleConfessionInternalId: bigint | null;
+  confessionInternalId: bigint | null;
   threadId: bigint | null;
 }
 
@@ -108,7 +108,7 @@ function createResolvedApprovedChannelThread(
   if (row.threadId === null) {
     if (row.pendingChannelThreadId !== null)
       AssertionError.throwNew('invalid approved channel thread row: pending owner without thread');
-    if (row.pendingChannelThreadTitleConfessionInternalId !== null)
+    if (row.confessionInternalId !== null)
       AssertionError.throwNew('invalid approved channel thread row: title owner without thread');
     return null;
   }
@@ -120,13 +120,12 @@ function createResolvedApprovedChannelThread(
     row.pendingChannelThreadId !== expectedPendingChannelThreadId
   )
     AssertionError.throwNew('invalid approved channel thread row: pending owner mismatch');
-  if (row.pendingChannelThreadTitleConfessionInternalId === null)
+  if (row.confessionInternalId === null)
     AssertionError.throwNew('invalid approved channel thread row: title owner missing');
 
   return {
     pendingChannelThreadId: row.pendingChannelThreadId,
-    pendingChannelThreadTitleConfessionInternalId:
-      row.pendingChannelThreadTitleConfessionInternalId,
+    confessionInternalId: row.confessionInternalId,
     threadId: row.threadId,
   };
 }
@@ -140,7 +139,7 @@ function createApprovedChannelThreadResolution(
       {
         pendingChannelThreadId:
           row.pendingApprovalThreadId === null ? null : row.pendingChannelThreadId,
-        pendingChannelThreadTitleConfessionInternalId: row.pendingApprovalTitleConfessionInternalId,
+        confessionInternalId: row.pendingApprovalTitleConfessionInternalId,
         threadId: row.pendingApprovalThreadId,
       },
       row.pendingChannelThreadId,
@@ -148,7 +147,7 @@ function createApprovedChannelThreadResolution(
     approvedForThread: createResolvedApprovedChannelThread(
       {
         pendingChannelThreadId: row.threadApprovalPendingChannelThreadId,
-        pendingChannelThreadTitleConfessionInternalId: row.threadApprovalTitleConfessionInternalId,
+        confessionInternalId: row.threadApprovalTitleConfessionInternalId,
         threadId: row.threadApprovalThreadId,
       },
       row.pendingChannelThreadId,
@@ -284,13 +283,12 @@ export async function insertConfession(
 
 async function loadApprovedChannelThreadResolution(
   db: Interface,
-  pendingChannelThreadTitleConfessionInternalId: bigint,
+  confessionInternalId: bigint,
   threadId: bigint,
 ) {
   return await tracer.asyncSpan('load-approved-channel-thread-resolution', async span => {
     span.setAttributes({
-      'pending.channel.thread.title.confession.internal.id':
-        pendingChannelThreadTitleConfessionInternalId.toString(),
+      'pending.channel.thread.title.confession.internal.id': confessionInternalId.toString(),
       'thread.id': threadId.toString(),
     });
 
@@ -298,17 +296,13 @@ async function loadApprovedChannelThreadResolution(
     const approvedThreadForPending = db
       .select({
         pendingChannelThreadId: approvedTitle.pendingChannelThreadId,
-        pendingChannelThreadTitleConfessionInternalId:
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+        confessionInternalId: schema.approvedChannelThread.confessionInternalId,
         threadId: schema.approvedChannelThread.threadId,
       })
       .from(schema.approvedChannelThread)
       .innerJoin(
         approvedTitle,
-        eq(
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
-          approvedTitle.confessionInternalId,
-        ),
+        eq(schema.approvedChannelThread.confessionInternalId, approvedTitle.confessionInternalId),
       )
       .as('approved_thread_for_pending');
 
@@ -319,15 +313,14 @@ async function loadApprovedChannelThreadResolution(
     const approvedThreadForThread = db
       .select({
         pendingChannelThreadId: approvedThreadTitle.pendingChannelThreadId,
-        pendingChannelThreadTitleConfessionInternalId:
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+        confessionInternalId: schema.approvedChannelThread.confessionInternalId,
         threadId: schema.approvedChannelThread.threadId,
       })
       .from(schema.approvedChannelThread)
       .innerJoin(
         approvedThreadTitle,
         eq(
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          schema.approvedChannelThread.confessionInternalId,
           approvedThreadTitle.confessionInternalId,
         ),
       )
@@ -337,12 +330,10 @@ async function loadApprovedChannelThreadResolution(
     const row = await db
       .select({
         pendingChannelThreadId: schema.pendingChannelThreadTitle.pendingChannelThreadId,
-        pendingApprovalTitleConfessionInternalId:
-          approvedThreadForPending.pendingChannelThreadTitleConfessionInternalId,
+        pendingApprovalTitleConfessionInternalId: approvedThreadForPending.confessionInternalId,
         pendingApprovalThreadId: approvedThreadForPending.threadId,
         threadApprovalPendingChannelThreadId: approvedThreadForThread.pendingChannelThreadId,
-        threadApprovalTitleConfessionInternalId:
-          approvedThreadForThread.pendingChannelThreadTitleConfessionInternalId,
+        threadApprovalTitleConfessionInternalId: approvedThreadForThread.confessionInternalId,
         threadApprovalThreadId: approvedThreadForThread.threadId,
       })
       .from(schema.pendingChannelThreadTitle)
@@ -363,12 +354,7 @@ async function loadApprovedChannelThreadResolution(
           eq(approvedThreadForThread.threadId, threadId),
         ),
       )
-      .where(
-        eq(
-          schema.pendingChannelThreadTitle.confessionInternalId,
-          pendingChannelThreadTitleConfessionInternalId,
-        ),
-      )
+      .where(eq(schema.pendingChannelThreadTitle.confessionInternalId, confessionInternalId))
       .limit(1)
       .then(assertSingle);
 
@@ -379,18 +365,17 @@ async function loadApprovedChannelThreadResolution(
 export async function resolveApprovedChannelThread(
   db: Transaction,
   threadId: bigint,
-  pendingChannelThreadTitleConfessionInternalId: bigint,
+  confessionInternalId: bigint,
 ) {
   return await tracer.asyncSpan('resolve-approved-channel-thread', async span => {
     span.setAttributes({
-      'pending.channel.thread.title.confession.internal.id':
-        pendingChannelThreadTitleConfessionInternalId.toString(),
+      'pending.channel.thread.title.confession.internal.id': confessionInternalId.toString(),
       'thread.id': threadId.toString(),
     });
 
     const resolution = await loadApprovedChannelThreadResolution(
       db,
-      pendingChannelThreadTitleConfessionInternalId,
+      confessionInternalId,
       threadId,
     );
     const { pendingChannelThreadId } = resolution;
@@ -402,7 +387,7 @@ export async function resolveApprovedChannelThread(
 
     const resolutionAfterLock = await loadApprovedChannelThreadResolution(
       db,
-      pendingChannelThreadTitleConfessionInternalId,
+      confessionInternalId,
       threadId,
     );
     if (resolutionAfterLock.approvedForPending !== null)
@@ -412,7 +397,7 @@ export async function resolveApprovedChannelThread(
       return resolutionAfterLock.approvedForThread;
 
     const { rowCount } = await db.insert(schema.approvedChannelThread).values({
-      pendingChannelThreadTitleConfessionInternalId,
+      confessionInternalId,
       threadId,
     });
 
@@ -423,7 +408,7 @@ export async function resolveApprovedChannelThread(
         logger.debug('approved channel thread inserted');
         return {
           pendingChannelThreadId,
-          pendingChannelThreadTitleConfessionInternalId,
+          confessionInternalId,
           threadId,
         };
       default:

--- a/src/lib/server/database/models/index.ts
+++ b/src/lib/server/database/models/index.ts
@@ -41,7 +41,10 @@ export const channel = app.table('channel', {
 export type Channel = typeof channel.$inferSelect;
 export type NewChannel = typeof channel.$inferInsert;
 
-export const pendingChannelThreadKind = app.enum('pending_channel_thread_kind', ['new-thread']);
+export const pendingChannelThreadKind = app.enum('pending_channel_thread_kind', [
+  'new-thread',
+  'new-thread-reply',
+]);
 export type PendingChannelThreadKind = (typeof pendingChannelThreadKind.enumValues)[number];
 
 export const pendingChannelThread = app.table(
@@ -53,9 +56,15 @@ export const pendingChannelThread = app.table(
       .references(() => channel.id, { onDelete: 'cascade' }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
     kind: pendingChannelThreadKind('kind').notNull(),
+    parentMessageId: bigint('parent_message_id', { mode: 'bigint' }),
     title: text('title').notNull(),
   },
-  ({ channelId }) => [index('pending_channel_thread_channel_id_idx').on(channelId)],
+  ({ channelId, parentMessageId }) => [
+    index('pending_channel_thread_channel_id_idx').on(channelId),
+    uniqueIndex('pending_channel_thread_reply_target_unique_idx')
+      .on(channelId, parentMessageId)
+      .where(isNotNull(parentMessageId)),
+  ],
 );
 
 export type PendingChannelThread = typeof pendingChannelThread.$inferSelect;

--- a/src/lib/server/database/models/index.ts
+++ b/src/lib/server/database/models/index.ts
@@ -25,18 +25,22 @@ export const guild = app.table('guild', {
 export type Guild = typeof guild.$inferSelect;
 export type NewGuild = typeof guild.$inferInsert;
 
-export const channel = app.table('channel', {
-  id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
-  guildId: bigint('guild_id', { mode: 'bigint' })
-    .notNull()
-    .references(() => guild.id, { onDelete: 'cascade' }),
-  // TODO: Eventually add the `notNull` constraint once all guilds have transitioned.
-  logChannelId: bigint('log_channel_id', { mode: 'bigint' }),
-  disabledAt: timestamp('disabled_at', { withTimezone: true }),
-  color: bit('color', { dimensions: 24 }),
-  isApprovalRequired: boolean('is_approval_required').notNull().default(false),
-  label: text('label').notNull().default('Confession'),
-});
+export const channel = app.table(
+  'channel',
+  {
+    id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
+    guildId: bigint('guild_id', { mode: 'bigint' })
+      .notNull()
+      .references(() => guild.id, { onDelete: 'cascade' }),
+    // TODO: Eventually add the `notNull` constraint once all guilds have transitioned.
+    logChannelId: bigint('log_channel_id', { mode: 'bigint' }),
+    disabledAt: timestamp('disabled_at', { withTimezone: true }),
+    color: bit('color', { dimensions: 24 }),
+    isApprovalRequired: boolean('is_approval_required').notNull().default(false),
+    label: text('label').notNull().default('Confession'),
+  },
+  ({ guildId }) => [index('channel_guild_id_idx').on(guildId)],
+);
 
 export type Channel = typeof channel.$inferSelect;
 export type NewChannel = typeof channel.$inferInsert;
@@ -55,9 +59,8 @@ export const pendingChannelThread = app.table(
       .notNull()
       .references(() => channel.id, { onDelete: 'cascade' }),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-    kind: pendingChannelThreadKind('kind').notNull(),
     parentMessageId: bigint('parent_message_id', { mode: 'bigint' }),
-    title: text('title').notNull(),
+    kind: pendingChannelThreadKind('kind').notNull(),
   },
   ({ channelId, parentMessageId }) => [
     index('pending_channel_thread_channel_id_idx').on(channelId),
@@ -70,18 +73,6 @@ export const pendingChannelThread = app.table(
 export type PendingChannelThread = typeof pendingChannelThread.$inferSelect;
 export type NewPendingChannelThread = typeof pendingChannelThread.$inferInsert;
 
-export const approvedChannelThread = app.table('approved_channel_thread', {
-  threadId: bigint('thread_id', { mode: 'bigint' }).notNull().primaryKey(),
-  pendingChannelThreadId: bigint('pending_channel_thread_id', { mode: 'bigint' })
-    .notNull()
-    .references(() => pendingChannelThread.id, { onDelete: 'cascade' })
-    .unique(),
-  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
-});
-
-export type ApprovedChannelThread = typeof approvedChannelThread.$inferSelect;
-export type NewApprovedChannelThread = typeof approvedChannelThread.$inferInsert;
-
 export const confession = app.table(
   'confession',
   {
@@ -92,9 +83,6 @@ export const confession = app.table(
     channelId: bigint('channel_id', { mode: 'bigint' })
       .notNull()
       .references(() => channel.id),
-    pendingChannelThreadId: bigint('pending_channel_thread_id', { mode: 'bigint' }).references(
-      () => pendingChannelThread.id,
-    ),
     parentMessageId: bigint('parent_message_id', { mode: 'bigint' }),
     // HACK: JSON.stringify cannot serialize a `bigint`, so we just type-cast it anyway.
     confessionId: bigint('confession_id', { mode: 'bigint' })
@@ -105,17 +93,53 @@ export const confession = app.table(
     authorId: bigint('author_id', { mode: 'bigint' }).notNull(),
     content: text('content').notNull(),
   },
-  ({ confessionId, channelId, pendingChannelThreadId }) => [
+  ({ confessionId, channelId }) => [
     index('confession_channel_id_idx').on(channelId),
-    index('confession_pending_channel_thread_id_idx')
-      .on(pendingChannelThreadId)
-      .where(isNotNull(pendingChannelThreadId)),
     uniqueIndex('confession_to_channel_unique_idx').on(confessionId, channelId),
   ],
 );
 
 export type Confession = typeof confession.$inferSelect;
 export type NewConfession = typeof confession.$inferInsert;
+
+export const pendingChannelThreadTitle = app.table(
+  'pending_channel_thread_title',
+  {
+    confessionInternalId: bigint('confession_internal_id', { mode: 'bigint' })
+      .notNull()
+      .primaryKey()
+      .references(() => confession.internalId, { onDelete: 'cascade' }),
+    pendingChannelThreadId: bigint('pending_channel_thread_id', { mode: 'bigint' })
+      .notNull()
+      .references(() => pendingChannelThread.id, { onDelete: 'cascade' }),
+    title: text('title').notNull(),
+  },
+  ({ confessionInternalId, pendingChannelThreadId }) => [
+    index('pending_channel_thread_title_pending_channel_thread_id_idx').on(pendingChannelThreadId),
+    uniqueIndex('pending_channel_thread_title_confession_thread_unique_idx').on(
+      confessionInternalId,
+      pendingChannelThreadId,
+    ),
+  ],
+);
+
+export type PendingChannelThreadTitle = typeof pendingChannelThreadTitle.$inferSelect;
+export type NewPendingChannelThreadTitle = typeof pendingChannelThreadTitle.$inferInsert;
+
+export const approvedChannelThread = app.table('approved_channel_thread', {
+  threadId: bigint('thread_id', { mode: 'bigint' }).notNull().primaryKey(),
+  pendingChannelThreadTitleConfessionInternalId: bigint(
+    'pending_channel_thread_title_confession_internal_id',
+    { mode: 'bigint' },
+  )
+    .notNull()
+    .references(() => pendingChannelThreadTitle.confessionInternalId, { onDelete: 'cascade' })
+    .unique(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export type ApprovedChannelThread = typeof approvedChannelThread.$inferSelect;
+export type NewApprovedChannelThread = typeof approvedChannelThread.$inferInsert;
 
 export const ephemeralAttachment = app.table('ephemeral_attachment', {
   id: bigint('id', { mode: 'bigint' }).notNull().primaryKey(),
@@ -153,10 +177,6 @@ export type NewDurableAttachment = typeof durableAttachment.$inferInsert;
 
 export const confessionRelations = relations(confession, ({ one }) => ({
   channel: one(channel, { fields: [confession.channelId], references: [channel.id] }),
-  pendingChannelThread: one(pendingChannelThread, {
-    fields: [confession.pendingChannelThreadId],
-    references: [pendingChannelThread.id],
-  }),
   attachment: one(ephemeralAttachment, {
     fields: [confession.internalId],
     references: [ephemeralAttachment.confessionInternalId],
@@ -172,19 +192,33 @@ export const pendingChannelThreadRelations = relations(pendingChannelThread, ({ 
     fields: [pendingChannelThread.channelId],
     references: [channel.id],
   }),
-  approvedChannelThread: one(approvedChannelThread, {
-    fields: [pendingChannelThread.id],
-    references: [approvedChannelThread.pendingChannelThreadId],
-  }),
-  confessions: many(confession),
+  titles: many(pendingChannelThreadTitle),
 }));
 
 export const approvedChannelThreadRelations = relations(approvedChannelThread, ({ one }) => ({
-  pendingChannelThread: one(pendingChannelThread, {
-    fields: [approvedChannelThread.pendingChannelThreadId],
-    references: [pendingChannelThread.id],
+  pendingChannelThreadTitle: one(pendingChannelThreadTitle, {
+    fields: [approvedChannelThread.pendingChannelThreadTitleConfessionInternalId],
+    references: [pendingChannelThreadTitle.confessionInternalId],
   }),
 }));
+
+export const pendingChannelThreadTitleRelations = relations(
+  pendingChannelThreadTitle,
+  ({ one }) => ({
+    confession: one(confession, {
+      fields: [pendingChannelThreadTitle.confessionInternalId],
+      references: [confession.internalId],
+    }),
+    pendingChannelThread: one(pendingChannelThread, {
+      fields: [pendingChannelThreadTitle.pendingChannelThreadId],
+      references: [pendingChannelThread.id],
+    }),
+    approvedChannelThread: one(approvedChannelThread, {
+      fields: [pendingChannelThreadTitle.confessionInternalId],
+      references: [approvedChannelThread.pendingChannelThreadTitleConfessionInternalId],
+    }),
+  }),
+);
 
 export const ephemeralAttachmentRelations = relations(ephemeralAttachment, ({ one }) => ({
   confession: one(confession, {

--- a/src/lib/server/database/models/index.ts
+++ b/src/lib/server/database/models/index.ts
@@ -114,12 +114,8 @@ export const pendingChannelThreadTitle = app.table(
       .references(() => pendingChannelThread.id, { onDelete: 'cascade' }),
     title: text('title').notNull(),
   },
-  ({ confessionInternalId, pendingChannelThreadId }) => [
+  ({ pendingChannelThreadId }) => [
     index('pending_channel_thread_title_pending_channel_thread_id_idx').on(pendingChannelThreadId),
-    uniqueIndex('pending_channel_thread_title_confession_thread_unique_idx').on(
-      confessionInternalId,
-      pendingChannelThreadId,
-    ),
   ],
 );
 
@@ -128,10 +124,7 @@ export type NewPendingChannelThreadTitle = typeof pendingChannelThreadTitle.$inf
 
 export const approvedChannelThread = app.table('approved_channel_thread', {
   threadId: bigint('thread_id', { mode: 'bigint' }).notNull().primaryKey(),
-  pendingChannelThreadTitleConfessionInternalId: bigint(
-    'pending_channel_thread_title_confession_internal_id',
-    { mode: 'bigint' },
-  )
+  confessionInternalId: bigint('confession_internal_id', { mode: 'bigint' })
     .notNull()
     .references(() => pendingChannelThreadTitle.confessionInternalId, { onDelete: 'cascade' })
     .unique(),
@@ -197,7 +190,7 @@ export const pendingChannelThreadRelations = relations(pendingChannelThread, ({ 
 
 export const approvedChannelThreadRelations = relations(approvedChannelThread, ({ one }) => ({
   pendingChannelThreadTitle: one(pendingChannelThreadTitle, {
-    fields: [approvedChannelThread.pendingChannelThreadTitleConfessionInternalId],
+    fields: [approvedChannelThread.confessionInternalId],
     references: [pendingChannelThreadTitle.confessionInternalId],
   }),
 }));
@@ -215,7 +208,7 @@ export const pendingChannelThreadTitleRelations = relations(
     }),
     approvedChannelThread: one(approvedChannelThread, {
       fields: [pendingChannelThreadTitle.confessionInternalId],
-      references: [approvedChannelThread.pendingChannelThreadTitleConfessionInternalId],
+      references: [approvedChannelThread.confessionInternalId],
     }),
   }),
 );

--- a/src/lib/server/inngest/functions/dispatch-approval/index.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/index.ts
@@ -4,8 +4,9 @@ import {
   ConfessionChannel,
   createConfessionPayload,
   getConfessionErrorMessage,
+  getThreadCreationErrorMessage,
 } from '$lib/server/confession';
-import { db } from '$lib/server/database';
+import { db, resolveApprovedChannelThread } from '$lib/server/database';
 import { DiscordClient } from '$lib/server/api/discord';
 import { DiscordError, DiscordErrorCode } from '$lib/server/models/discord/errors';
 import { inngest } from '$lib/server/inngest/client';
@@ -13,13 +14,29 @@ import { Logger } from '$lib/server/telemetry/logger';
 import { MessageFlags } from '$lib/server/models/discord/message/base';
 import { Tracer } from '$lib/server/telemetry/tracer';
 
+import {
+  type ApprovalDispatchConfession,
+  FatalApprovalDispatchStateError,
+  serializeLoadedApprovalConfession,
+} from './state';
 import { ConfessionApprovalEvent } from './schema';
-import { FatalApprovalDispatchStateError, serializeResolvedApprovalConfession } from './state';
-import { insertApprovedChannelThread, loadApprovalDispatchConfession } from './query';
+import { loadApprovalDispatchConfession } from './query';
 
 const SERVICE_NAME = 'inngest.dispatch-approval';
 const logger = Logger.byName(SERVICE_NAME);
 const tracer = Tracer.byName(SERVICE_NAME);
+
+interface CreatedThreadResult {
+  ok: true;
+  threadId: string;
+}
+
+interface FailedThreadCreationResult {
+  ok: false;
+  content: string;
+}
+
+type ThreadCreationResult = CreatedThreadResult | FailedThreadCreationResult;
 
 export const dispatchApproval = inngest.createFunction(
   {
@@ -38,8 +55,8 @@ export const dispatchApproval = inngest.createFunction(
         'inngest.event.data.interactionId': event.data.interactionId,
       });
 
-      const confession = await step.run(
-        { id: 'resolve-approved-confession', name: 'Resolve Approved Confession' },
+      const loaded = await step.run(
+        { id: 'load-approved-confession', name: 'Load Approved Confession' },
         async () => {
           const loaded = await loadApprovalDispatchConfession(db, BigInt(event.data.internalId));
           if (typeof loaded === 'undefined')
@@ -53,27 +70,114 @@ export const dispatchApproval = inngest.createFunction(
             'confession.parent.message.id': loaded.parentMessageId?.toString() ?? null,
           });
 
-          const { pendingThread } = loaded;
-          if (pendingThread === null || pendingThread.approved !== null)
-            return serializeResolvedApprovalConfession(loaded);
-
-          const thread = await DiscordClient.ENV.createPublicThread(
-            loaded.channelId.toString(),
-            pendingThread.title,
-          );
-
-          const threadId = BigInt(thread.id);
-          await insertApprovedChannelThread(db, pendingThread.id, threadId);
-
-          return serializeResolvedApprovalConfession({
-            ...loaded,
-            pendingThread: {
-              ...pendingThread,
-              approved: { threadId },
-            },
-          });
+          return serializeLoadedApprovalConfession(loaded);
         },
       );
+
+      let resolvedThreadId: string | null = null;
+      let pendingChannelThreadId: string | null = null;
+      let thread: ApprovalDispatchConfession['thread'] = null;
+      if (loaded.pendingThread !== null) {
+        const { pendingThread } = loaded;
+        pendingChannelThreadId = pendingThread.id;
+        resolvedThreadId = pendingThread.approvedThreadId;
+
+        if (resolvedThreadId === null) {
+          const threadResult = await step.run(
+            { id: 'create-discord-thread', name: 'Create Discord Thread' },
+            async (): Promise<ThreadCreationResult> => {
+              try {
+                if (pendingThread.parentMessageId === null) {
+                  const thread = await DiscordClient.ENV.createPublicThread(
+                    loaded.channelId,
+                    pendingThread.title,
+                  );
+                  return { ok: true, threadId: thread.id };
+                }
+
+                const thread = await DiscordClient.ENV.createPublicThreadFromMessage(
+                  loaded.channelId,
+                  pendingThread.parentMessageId,
+                  pendingThread.title,
+                );
+                return { ok: true, threadId: thread.id };
+              } catch (error) {
+                if (error instanceof DiscordError)
+                  switch (error.code) {
+                    case DiscordErrorCode.ThreadAlreadyCreatedForMessage:
+                      if (pendingThread.parentMessageId !== null)
+                        return {
+                          ok: true,
+                          threadId: pendingThread.parentMessageId,
+                        };
+                      return {
+                        ok: false,
+                        content: getThreadCreationErrorMessage(error.code, {
+                          label: loaded.channel.label,
+                          confessionId: loaded.confessionId,
+                        }),
+                      };
+                    case DiscordErrorCode.UnknownChannel:
+                    case DiscordErrorCode.MissingAccess:
+                    case DiscordErrorCode.MissingPermissions:
+                    case DiscordErrorCode.ThreadLocked:
+                    case DiscordErrorCode.MaxActiveThreadsReached:
+                      return {
+                        ok: false,
+                        content: getThreadCreationErrorMessage(error.code, {
+                          label: loaded.channel.label,
+                          confessionId: loaded.confessionId,
+                        }),
+                      };
+                    default:
+                      break;
+                  }
+                throw error;
+              }
+            },
+          );
+
+          if (!threadResult.ok)
+            FatalApprovalDispatchStateError.throwNew('approved thread destination unavailable', {
+              'confession.id': loaded.confessionId,
+              'failure.message': threadResult.content,
+            });
+
+          resolvedThreadId = await step.run(
+            { id: 'resolve-approved-thread', name: 'Resolve Approved Thread' },
+            async () => {
+              const approved = await db.transaction(
+                async tx =>
+                  await resolveApprovedChannelThread(
+                    tx,
+                    BigInt(pendingThread.id),
+                    BigInt(threadResult.threadId),
+                  ),
+                { isolationLevel: 'read committed' },
+              );
+              return approved.threadId.toString();
+            },
+          );
+        }
+
+        thread = {
+          id: resolvedThreadId,
+          title: pendingThread.title,
+        };
+      }
+
+      const confession: ApprovalDispatchConfession = {
+        confessionId: loaded.confessionId,
+        channelId: loaded.channelId,
+        pendingChannelThreadId,
+        publishChannelId: resolvedThreadId ?? loaded.channelId,
+        content: loaded.content,
+        createdAt: loaded.createdAt,
+        parentMessageId: loaded.parentMessageId,
+        channel: loaded.channel,
+        thread,
+        attachment: loaded.attachment,
+      };
 
       const result = await step.run(
         { id: 'dispatch-approval', name: 'Dispatch Approved Confession' },

--- a/src/lib/server/inngest/functions/dispatch-approval/index.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/index.ts
@@ -174,6 +174,7 @@ export const dispatchApproval = inngest.createFunction(
         content: loaded.content,
         createdAt: loaded.createdAt,
         parentMessageId: loaded.parentMessageId,
+        pendingThreadTitle: loaded.pendingThread?.title ?? null,
         channel: loaded.channel,
         thread,
         attachment: loaded.attachment,

--- a/src/lib/server/inngest/functions/dispatch-approval/index.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/index.ts
@@ -150,8 +150,8 @@ export const dispatchApproval = inngest.createFunction(
                 async tx =>
                   await resolveApprovedChannelThread(
                     tx,
-                    BigInt(pendingThread.id),
                     BigInt(threadResult.threadId),
+                    BigInt(event.data.internalId),
                   ),
                 { isolationLevel: 'read committed' },
               );

--- a/src/lib/server/inngest/functions/dispatch-approval/query.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/query.ts
@@ -203,17 +203,13 @@ export async function loadApprovalDispatchConfession(db: Interface, internalId: 
       .select({
         approvedPendingChannelThreadId: approvedTitle.pendingChannelThreadId,
         approvedThreadTitle: approvedTitle.title,
-        approvedThreadTitleConfessionInternalId:
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+        approvedThreadTitleConfessionInternalId: schema.approvedChannelThread.confessionInternalId,
         approvedThreadId: schema.approvedChannelThread.threadId,
       })
       .from(schema.approvedChannelThread)
       .innerJoin(
         approvedTitle,
-        eq(
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
-          approvedTitle.confessionInternalId,
-        ),
+        eq(schema.approvedChannelThread.confessionInternalId, approvedTitle.confessionInternalId),
       )
       .as('approved_thread_for_pending');
 

--- a/src/lib/server/inngest/functions/dispatch-approval/query.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/query.ts
@@ -3,54 +3,12 @@ import { eq } from 'drizzle-orm';
 import * as schema from '$lib/server/database/models';
 import { AssertionError, assertOptional } from '$lib/assert';
 import type { Interface } from '$lib/server/database';
-import { Logger } from '$lib/server/telemetry/logger';
 import { Tracer } from '$lib/server/telemetry/tracer';
-import { UnexpectedRowCountDatabaseError } from '$lib/server/database/errors';
+
+import type { ApprovalDispatchConfessionState } from './state';
 
 const SERVICE_NAME = 'inngest.dispatch-approval.query';
-const logger = Logger.byName(SERVICE_NAME);
 const tracer = Tracer.byName(SERVICE_NAME);
-
-interface DurableAttachmentState {
-  id: bigint;
-  filename: string;
-  contentType: string | null;
-  url: string;
-  proxyUrl: string;
-  height: number | null;
-  width: number | null;
-}
-
-interface AttachmentState {
-  id: bigint;
-  durable: DurableAttachmentState;
-}
-
-interface ApprovedThreadState {
-  threadId: bigint;
-}
-
-interface PendingThreadState {
-  id: bigint;
-  title: string;
-  approved: ApprovedThreadState | null;
-}
-
-export interface ApprovalDispatchConfessionState {
-  confessionId: bigint;
-  channelId: bigint;
-  content: string;
-  createdAt: Date;
-  approvedAt: Date;
-  parentMessageId: bigint | null;
-  channel: {
-    guildId: bigint;
-    label: string;
-    color: string | null;
-  };
-  pendingThread: PendingThreadState | null;
-  attachment: AttachmentState | null;
-}
 
 interface FlatApprovalDispatchConfessionRow {
   confessionId: bigint;
@@ -65,6 +23,7 @@ interface FlatApprovalDispatchConfessionRow {
   color: string | null;
   threadPendingChannelThreadId: bigint | null;
   threadTitle: string | null;
+  threadParentMessageId: bigint | null;
   approvedPendingChannelThreadId: bigint | null;
   approvedThreadId: bigint | null;
   attachmentId: bigint | null;
@@ -98,6 +57,7 @@ type PendingThreadRow = Pick<
   | 'approvedPendingChannelThreadId'
   | 'approvedThreadId'
   | 'pendingChannelThreadId'
+  | 'threadParentMessageId'
   | 'threadPendingChannelThreadId'
   | 'threadTitle'
 >;
@@ -176,6 +136,7 @@ function createPendingThread(row: PendingThreadRow) {
     return {
       id: row.pendingChannelThreadId,
       title: row.threadTitle,
+      parentMessageId: row.threadParentMessageId,
       approved: null,
     };
   }
@@ -187,6 +148,7 @@ function createPendingThread(row: PendingThreadRow) {
   return {
     id: row.pendingChannelThreadId,
     title: row.threadTitle,
+    parentMessageId: row.threadParentMessageId,
     approved: {
       threadId: row.approvedThreadId,
     },
@@ -216,81 +178,59 @@ function createApprovalDispatchConfession(
 }
 
 export async function loadApprovalDispatchConfession(db: Interface, internalId: bigint) {
-  const row = await db
-    .select({
-      confessionId: schema.confession.confessionId,
-      channelId: schema.confession.channelId,
-      pendingChannelThreadId: schema.confession.pendingChannelThreadId,
-      content: schema.confession.content,
-      createdAt: schema.confession.createdAt,
-      approvedAt: schema.confession.approvedAt,
-      parentMessageId: schema.confession.parentMessageId,
-      guildId: schema.channel.guildId,
-      label: schema.channel.label,
-      color: schema.channel.color,
-      threadPendingChannelThreadId: schema.pendingChannelThread.id,
-      threadTitle: schema.pendingChannelThread.title,
-      approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
-      approvedThreadId: schema.approvedChannelThread.threadId,
-      attachmentId: schema.ephemeralAttachment.id,
-      durableAttachmentId: schema.durableAttachment.id,
-      durableAttachmentEphemeralId: schema.durableAttachment.ephemeralAttachmentId,
-      durableAttachmentFilename: schema.durableAttachment.filename,
-      durableAttachmentContentType: schema.durableAttachment.contentType,
-      durableAttachmentUrl: schema.durableAttachment.url,
-      durableAttachmentProxyUrl: schema.durableAttachment.proxyUrl,
-      durableAttachmentHeight: schema.durableAttachment.height,
-      durableAttachmentWidth: schema.durableAttachment.width,
-    })
-    .from(schema.confession)
-    .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
-    .leftJoin(
-      schema.pendingChannelThread,
-      eq(schema.confession.pendingChannelThreadId, schema.pendingChannelThread.id),
-    )
-    .leftJoin(
-      schema.approvedChannelThread,
-      eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
-    )
-    .leftJoin(
-      schema.ephemeralAttachment,
-      eq(schema.confession.internalId, schema.ephemeralAttachment.confessionInternalId),
-    )
-    .leftJoin(
-      schema.durableAttachment,
-      eq(schema.ephemeralAttachment.id, schema.durableAttachment.ephemeralAttachmentId),
-    )
-    .where(eq(schema.confession.internalId, internalId))
-    .limit(1)
-    .then(assertOptional);
-  if (typeof row === 'undefined') return;
-  return createApprovalDispatchConfession(row);
-}
+  return await tracer.asyncSpan('load-approval-dispatch-confession', async span => {
+    span.setAttribute('confession.internal.id', internalId.toString());
 
-export async function insertApprovedChannelThread(
-  db: Interface,
-  pendingChannelThreadId: bigint,
-  threadId: bigint,
-) {
-  return await tracer.asyncSpan('insert-approved-channel-thread', async span => {
-    span.setAttributes({
-      'pending.channel.thread.id': pendingChannelThreadId.toString(),
-      'thread.id': threadId.toString(),
-    });
+    const row = await db
+      .select({
+        confessionId: schema.confession.confessionId,
+        channelId: schema.confession.channelId,
+        pendingChannelThreadId: schema.confession.pendingChannelThreadId,
+        content: schema.confession.content,
+        createdAt: schema.confession.createdAt,
+        approvedAt: schema.confession.approvedAt,
+        parentMessageId: schema.confession.parentMessageId,
+        guildId: schema.channel.guildId,
+        label: schema.channel.label,
+        color: schema.channel.color,
+        threadPendingChannelThreadId: schema.pendingChannelThread.id,
+        threadTitle: schema.pendingChannelThread.title,
+        threadParentMessageId: schema.pendingChannelThread.parentMessageId,
+        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        approvedThreadId: schema.approvedChannelThread.threadId,
+        attachmentId: schema.ephemeralAttachment.id,
+        durableAttachmentId: schema.durableAttachment.id,
+        durableAttachmentEphemeralId: schema.durableAttachment.ephemeralAttachmentId,
+        durableAttachmentFilename: schema.durableAttachment.filename,
+        durableAttachmentContentType: schema.durableAttachment.contentType,
+        durableAttachmentUrl: schema.durableAttachment.url,
+        durableAttachmentProxyUrl: schema.durableAttachment.proxyUrl,
+        durableAttachmentHeight: schema.durableAttachment.height,
+        durableAttachmentWidth: schema.durableAttachment.width,
+      })
+      .from(schema.confession)
+      .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
+      .leftJoin(
+        schema.pendingChannelThread,
+        eq(schema.confession.pendingChannelThreadId, schema.pendingChannelThread.id),
+      )
+      .leftJoin(
+        schema.approvedChannelThread,
+        eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
+      )
+      .leftJoin(
+        schema.ephemeralAttachment,
+        eq(schema.confession.internalId, schema.ephemeralAttachment.confessionInternalId),
+      )
+      .leftJoin(
+        schema.durableAttachment,
+        eq(schema.ephemeralAttachment.id, schema.durableAttachment.ephemeralAttachmentId),
+      )
+      .where(eq(schema.confession.internalId, internalId))
+      .limit(1)
+      .then(assertOptional);
+    if (typeof row === 'undefined') return;
 
-    const { rowCount } = await db.insert(schema.approvedChannelThread).values({
-      pendingChannelThreadId,
-      threadId,
-    });
-
-    switch (rowCount) {
-      case null:
-        return UnexpectedRowCountDatabaseError.throwNew();
-      case 1:
-        logger.debug('approved channel thread inserted');
-        return;
-      default:
-        return UnexpectedRowCountDatabaseError.throwNew(rowCount);
-    }
+    return createApprovalDispatchConfession(row);
   });
 }

--- a/src/lib/server/inngest/functions/dispatch-approval/query.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/query.ts
@@ -1,4 +1,4 @@
-import { eq } from 'drizzle-orm';
+import { aliasedTable, eq } from 'drizzle-orm';
 
 import * as schema from '$lib/server/database/models';
 import { AssertionError, assertOptional } from '$lib/assert';
@@ -22,9 +22,11 @@ interface FlatApprovalDispatchConfessionRow {
   label: string;
   color: string | null;
   threadPendingChannelThreadId: bigint | null;
-  threadTitle: string | null;
+  requestedThreadTitle: string | null;
+  approvedThreadTitle: string | null;
   threadParentMessageId: bigint | null;
   approvedPendingChannelThreadId: bigint | null;
+  approvedThreadTitleConfessionInternalId: bigint | null;
   approvedThreadId: bigint | null;
   attachmentId: bigint | null;
   durableAttachmentId: bigint | null;
@@ -56,10 +58,12 @@ type PendingThreadRow = Pick<
   FlatApprovalDispatchConfessionRow,
   | 'approvedPendingChannelThreadId'
   | 'approvedThreadId'
+  | 'approvedThreadTitle'
+  | 'approvedThreadTitleConfessionInternalId'
   | 'pendingChannelThreadId'
+  | 'requestedThreadTitle'
   | 'threadParentMessageId'
   | 'threadPendingChannelThreadId'
-  | 'threadTitle'
 >;
 
 function createDurableAttachment(row: DurableAttachmentRow) {
@@ -112,8 +116,12 @@ function createPendingThread(row: PendingThreadRow) {
   if (row.pendingChannelThreadId === null) {
     if (row.threadPendingChannelThreadId !== null)
       AssertionError.throwNew('invalid approval dispatch row: orphan pending thread row');
-    if (row.threadTitle !== null)
-      AssertionError.throwNew('invalid approval dispatch row: orphan pending thread title');
+    if (row.requestedThreadTitle !== null)
+      AssertionError.throwNew('invalid approval dispatch row: orphan requested thread title');
+    if (row.approvedThreadTitle !== null)
+      AssertionError.throwNew('invalid approval dispatch row: orphan approved thread title');
+    if (row.approvedThreadTitleConfessionInternalId !== null)
+      AssertionError.throwNew('invalid approval dispatch row: orphan approved title owner');
     if (row.approvedPendingChannelThreadId !== null)
       AssertionError.throwNew('invalid approval dispatch row: orphan approved thread owner');
     if (row.approvedThreadId !== null)
@@ -125,17 +133,21 @@ function createPendingThread(row: PendingThreadRow) {
     AssertionError.throwNew('invalid approval dispatch row: pending thread row missing');
   if (row.threadPendingChannelThreadId !== row.pendingChannelThreadId)
     AssertionError.throwNew('invalid approval dispatch row: pending thread id mismatch');
-  if (row.threadTitle === null)
-    AssertionError.throwNew('invalid approval dispatch row: pending thread title missing');
+  if (row.requestedThreadTitle === null)
+    AssertionError.throwNew('invalid approval dispatch row: requested thread title missing');
 
   if (row.approvedThreadId === null) {
     if (row.approvedPendingChannelThreadId !== null)
       AssertionError.throwNew(
         'invalid approval dispatch row: approved thread owner without thread id',
       );
+    if (row.approvedThreadTitleConfessionInternalId !== null)
+      AssertionError.throwNew('invalid approval dispatch row: approved title without thread id');
+    if (row.approvedThreadTitle !== null)
+      AssertionError.throwNew('invalid approval dispatch row: approved title without thread id');
     return {
       id: row.pendingChannelThreadId,
-      title: row.threadTitle,
+      title: row.requestedThreadTitle,
       parentMessageId: row.threadParentMessageId,
       approved: null,
     };
@@ -145,9 +157,13 @@ function createPendingThread(row: PendingThreadRow) {
     AssertionError.throwNew('invalid approval dispatch row: approved thread owner missing');
   if (row.approvedPendingChannelThreadId !== row.pendingChannelThreadId)
     AssertionError.throwNew('invalid approval dispatch row: approved thread owner mismatch');
+  if (row.approvedThreadTitleConfessionInternalId === null)
+    AssertionError.throwNew('invalid approval dispatch row: approved title owner missing');
+  if (row.approvedThreadTitle === null)
+    AssertionError.throwNew('invalid approval dispatch row: approved thread title missing');
   return {
     id: row.pendingChannelThreadId,
-    title: row.threadTitle,
+    title: row.approvedThreadTitle,
     parentMessageId: row.threadParentMessageId,
     approved: {
       threadId: row.approvedThreadId,
@@ -181,11 +197,31 @@ export async function loadApprovalDispatchConfession(db: Interface, internalId: 
   return await tracer.asyncSpan('load-approval-dispatch-confession', async span => {
     span.setAttribute('confession.internal.id', internalId.toString());
 
+    const requestedTitle = aliasedTable(schema.pendingChannelThreadTitle, 'requested_title');
+    const approvedTitle = aliasedTable(schema.pendingChannelThreadTitle, 'approved_title');
+    const approvedThreadForPending = db
+      .select({
+        approvedPendingChannelThreadId: approvedTitle.pendingChannelThreadId,
+        approvedThreadTitle: approvedTitle.title,
+        approvedThreadTitleConfessionInternalId:
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+        approvedThreadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.approvedChannelThread)
+      .innerJoin(
+        approvedTitle,
+        eq(
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          approvedTitle.confessionInternalId,
+        ),
+      )
+      .as('approved_thread_for_pending');
+
     const row = await db
       .select({
         confessionId: schema.confession.confessionId,
         channelId: schema.confession.channelId,
-        pendingChannelThreadId: schema.confession.pendingChannelThreadId,
+        pendingChannelThreadId: requestedTitle.pendingChannelThreadId,
         content: schema.confession.content,
         createdAt: schema.confession.createdAt,
         approvedAt: schema.confession.approvedAt,
@@ -194,10 +230,13 @@ export async function loadApprovalDispatchConfession(db: Interface, internalId: 
         label: schema.channel.label,
         color: schema.channel.color,
         threadPendingChannelThreadId: schema.pendingChannelThread.id,
-        threadTitle: schema.pendingChannelThread.title,
+        requestedThreadTitle: requestedTitle.title,
         threadParentMessageId: schema.pendingChannelThread.parentMessageId,
-        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
-        approvedThreadId: schema.approvedChannelThread.threadId,
+        approvedPendingChannelThreadId: approvedThreadForPending.approvedPendingChannelThreadId,
+        approvedThreadTitle: approvedThreadForPending.approvedThreadTitle,
+        approvedThreadTitleConfessionInternalId:
+          approvedThreadForPending.approvedThreadTitleConfessionInternalId,
+        approvedThreadId: approvedThreadForPending.approvedThreadId,
         attachmentId: schema.ephemeralAttachment.id,
         durableAttachmentId: schema.durableAttachment.id,
         durableAttachmentEphemeralId: schema.durableAttachment.ephemeralAttachmentId,
@@ -211,12 +250,19 @@ export async function loadApprovalDispatchConfession(db: Interface, internalId: 
       .from(schema.confession)
       .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
       .leftJoin(
-        schema.pendingChannelThread,
-        eq(schema.confession.pendingChannelThreadId, schema.pendingChannelThread.id),
+        requestedTitle,
+        eq(schema.confession.internalId, requestedTitle.confessionInternalId),
       )
       .leftJoin(
-        schema.approvedChannelThread,
-        eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
+        schema.pendingChannelThread,
+        eq(requestedTitle.pendingChannelThreadId, schema.pendingChannelThread.id),
+      )
+      .leftJoin(
+        approvedThreadForPending,
+        eq(
+          requestedTitle.pendingChannelThreadId,
+          approvedThreadForPending.approvedPendingChannelThreadId,
+        ),
       )
       .leftJoin(
         schema.ephemeralAttachment,

--- a/src/lib/server/inngest/functions/dispatch-approval/query.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/query.ts
@@ -163,7 +163,7 @@ function createPendingThread(row: PendingThreadRow) {
     AssertionError.throwNew('invalid approval dispatch row: approved thread title missing');
   return {
     id: row.pendingChannelThreadId,
-    title: row.approvedThreadTitle,
+    title: row.requestedThreadTitle,
     parentMessageId: row.threadParentMessageId,
     approved: {
       threadId: row.approvedThreadId,

--- a/src/lib/server/inngest/functions/dispatch-approval/state.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/state.ts
@@ -87,6 +87,7 @@ export interface ApprovalDispatchConfession {
   content: string;
   createdAt: string;
   parentMessageId: string | null;
+  pendingThreadTitle: string | null;
   channel: {
     guildId: string;
     label: string;

--- a/src/lib/server/inngest/functions/dispatch-approval/state.ts
+++ b/src/lib/server/inngest/functions/dispatch-approval/state.ts
@@ -4,8 +4,6 @@ import { NonRetriableError } from 'inngest';
 import { Logger } from '$lib/server/telemetry/logger';
 import type { SerializedAttachment } from '$lib/server/confession';
 
-import type { ApprovalDispatchConfessionState } from './query';
-
 const SERVICE_NAME = 'inngest.dispatch-approval.state';
 const logger = Logger.byName(SERVICE_NAME);
 
@@ -15,6 +13,70 @@ export class FatalApprovalDispatchStateError extends NonRetriableError {
     logger.fatal(message, error, attributes);
     throw error;
   }
+}
+
+interface DurableAttachmentState {
+  id: bigint;
+  filename: string;
+  contentType: string | null;
+  url: string;
+  proxyUrl: string;
+  height: number | null;
+  width: number | null;
+}
+
+interface AttachmentState {
+  id: bigint;
+  durable: DurableAttachmentState;
+}
+
+interface ApprovedThreadState {
+  threadId: bigint;
+}
+
+interface PendingThreadState {
+  id: bigint;
+  title: string;
+  parentMessageId: bigint | null;
+  approved: ApprovedThreadState | null;
+}
+
+export interface ApprovalDispatchConfessionState {
+  confessionId: bigint;
+  channelId: bigint;
+  content: string;
+  createdAt: Date;
+  approvedAt: Date;
+  parentMessageId: bigint | null;
+  channel: {
+    guildId: bigint;
+    label: string;
+    color: string | null;
+  };
+  pendingThread: PendingThreadState | null;
+  attachment: AttachmentState | null;
+}
+
+interface LoadedPendingThread {
+  id: string;
+  title: string;
+  parentMessageId: string | null;
+  approvedThreadId: string | null;
+}
+
+export interface LoadedApprovalConfession {
+  confessionId: string;
+  channelId: string;
+  content: string;
+  createdAt: string;
+  parentMessageId: string | null;
+  channel: {
+    guildId: string;
+    label: string;
+    color: string | null;
+  };
+  pendingThread: LoadedPendingThread | null;
+  attachment: SerializedAttachment | null;
 }
 
 export interface ApprovalDispatchConfession {
@@ -37,68 +99,46 @@ export interface ApprovalDispatchConfession {
   attachment: SerializedAttachment | null;
 }
 
-type ResolvedApprovalConfessionSource = Pick<
-  ApprovalDispatchConfessionState,
-  | 'attachment'
-  | 'channel'
-  | 'channelId'
-  | 'confessionId'
-  | 'content'
-  | 'createdAt'
-  | 'parentMessageId'
-  | 'pendingThread'
->;
+export function serializeLoadedApprovalConfession(
+  loaded: ApprovalDispatchConfessionState,
+): LoadedApprovalConfession {
+  const { pendingThread } = loaded;
 
-function serializeAttachment(
-  confession: Pick<ApprovalDispatchConfessionState, 'attachment'>,
-): SerializedAttachment | null {
-  if (confession.attachment === null) return null;
-  const { durable } = confession.attachment;
-  return {
-    id: durable.id.toString(),
-    filename: durable.filename,
-    contentType: durable.contentType,
-    url: durable.url,
-    proxyUrl: durable.proxyUrl,
-    height: durable.height,
-    width: durable.width,
-  };
-}
+  let attachment: SerializedAttachment | null = null;
+  if (loaded.attachment !== null) {
+    const { durable } = loaded.attachment;
+    attachment = {
+      id: durable.id.toString(),
+      filename: durable.filename,
+      contentType: durable.contentType,
+      url: durable.url,
+      proxyUrl: durable.proxyUrl,
+      height: durable.height,
+      width: durable.width,
+    };
+  }
 
-export function serializeResolvedApprovalConfession(
-  confession: ResolvedApprovalConfessionSource,
-): ApprovalDispatchConfession {
-  const { pendingThread } = confession;
-  const approvedThread = pendingThread?.approved ?? null;
-  if (pendingThread !== null && approvedThread === null)
-    return FatalApprovalDispatchStateError.throwNew(
-      'approved confession thread destination unresolved',
-      { 'pending.channel.thread.id': pendingThread.id.toString() },
-    );
-
-  const pendingChannelThreadId = pendingThread?.id.toString() ?? null;
-  const publishChannelId = approvedThread?.threadId.toString() ?? confession.channelId.toString();
+  let loadedPendingThread: LoadedPendingThread | null = null;
+  if (pendingThread !== null)
+    loadedPendingThread = {
+      id: pendingThread.id.toString(),
+      title: pendingThread.title,
+      parentMessageId: pendingThread.parentMessageId?.toString() ?? null,
+      approvedThreadId: pendingThread.approved?.threadId.toString() ?? null,
+    };
 
   return {
-    confessionId: confession.confessionId.toString(),
-    channelId: confession.channelId.toString(),
-    pendingChannelThreadId,
-    publishChannelId,
-    content: confession.content,
-    createdAt: confession.createdAt.toISOString(),
-    parentMessageId: confession.parentMessageId?.toString() ?? null,
+    confessionId: loaded.confessionId.toString(),
+    channelId: loaded.channelId.toString(),
+    content: loaded.content,
+    createdAt: loaded.createdAt.toISOString(),
+    parentMessageId: loaded.parentMessageId?.toString() ?? null,
     channel: {
-      guildId: confession.channel.guildId.toString(),
-      label: confession.channel.label,
-      color: confession.channel.color,
+      guildId: loaded.channel.guildId.toString(),
+      label: loaded.channel.label,
+      color: loaded.channel.color,
     },
-    thread:
-      approvedThread === null || pendingThread === null
-        ? null
-        : {
-            id: approvedThread.threadId.toString(),
-            title: pendingThread.title,
-          },
-    attachment: serializeAttachment(confession),
+    pendingThread: loadedPendingThread,
+    attachment,
   };
 }

--- a/src/lib/server/inngest/functions/process-confession-resend/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-resend/query.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { aliasedTable, and, eq } from 'drizzle-orm';
 
 import * as schema from '$lib/server/database/models';
 import { AssertionError, assertOptional } from '$lib/assert';
@@ -24,9 +24,11 @@ interface FlatResendConfessionRow {
   color: string | null;
   logChannelId: bigint | null;
   threadPendingChannelThreadId: bigint | null;
-  threadTitle: string | null;
+  requestedThreadTitle: string | null;
+  approvedThreadTitle: string | null;
   threadParentMessageId: bigint | null;
   approvedPendingChannelThreadId: bigint | null;
+  approvedThreadTitleConfessionInternalId: bigint | null;
   approvedThreadId: bigint | null;
   attachmentId: bigint | null;
   durableAttachmentId: bigint | null;
@@ -58,10 +60,12 @@ type PendingThreadRow = Pick<
   FlatResendConfessionRow,
   | 'approvedPendingChannelThreadId'
   | 'approvedThreadId'
+  | 'approvedThreadTitle'
+  | 'approvedThreadTitleConfessionInternalId'
   | 'pendingChannelThreadId'
+  | 'requestedThreadTitle'
   | 'threadParentMessageId'
   | 'threadPendingChannelThreadId'
-  | 'threadTitle'
 >;
 
 function createDurableAttachment(row: DurableAttachmentRow) {
@@ -108,8 +112,12 @@ function createPendingThread(row: PendingThreadRow) {
   if (row.pendingChannelThreadId === null) {
     if (row.threadPendingChannelThreadId !== null)
       AssertionError.throwNew('invalid resend confession row: orphan pending thread row');
-    if (row.threadTitle !== null)
-      AssertionError.throwNew('invalid resend confession row: orphan pending thread title');
+    if (row.requestedThreadTitle !== null)
+      AssertionError.throwNew('invalid resend confession row: orphan requested thread title');
+    if (row.approvedThreadTitle !== null)
+      AssertionError.throwNew('invalid resend confession row: orphan approved thread title');
+    if (row.approvedThreadTitleConfessionInternalId !== null)
+      AssertionError.throwNew('invalid resend confession row: orphan approved title owner');
     if (row.approvedPendingChannelThreadId !== null)
       AssertionError.throwNew('invalid resend confession row: orphan approved thread owner');
     if (row.approvedThreadId !== null)
@@ -121,17 +129,21 @@ function createPendingThread(row: PendingThreadRow) {
     AssertionError.throwNew('invalid resend confession row: pending thread row missing');
   if (row.threadPendingChannelThreadId !== row.pendingChannelThreadId)
     AssertionError.throwNew('invalid resend confession row: pending thread id mismatch');
-  if (row.threadTitle === null)
-    AssertionError.throwNew('invalid resend confession row: pending thread title missing');
+  if (row.requestedThreadTitle === null)
+    AssertionError.throwNew('invalid resend confession row: requested thread title missing');
 
   if (row.approvedThreadId === null) {
     if (row.approvedPendingChannelThreadId !== null)
       AssertionError.throwNew(
         'invalid resend confession row: approved thread owner without thread id',
       );
+    if (row.approvedThreadTitleConfessionInternalId !== null)
+      AssertionError.throwNew('invalid resend confession row: approved title without thread id');
+    if (row.approvedThreadTitle !== null)
+      AssertionError.throwNew('invalid resend confession row: approved title without thread id');
     return {
       id: row.pendingChannelThreadId,
-      title: row.threadTitle,
+      title: row.requestedThreadTitle,
       parentMessageId: row.threadParentMessageId,
       approved: null,
     };
@@ -141,9 +153,13 @@ function createPendingThread(row: PendingThreadRow) {
     AssertionError.throwNew('invalid resend confession row: approved thread owner missing');
   if (row.approvedPendingChannelThreadId !== row.pendingChannelThreadId)
     AssertionError.throwNew('invalid resend confession row: approved thread owner mismatch');
+  if (row.approvedThreadTitleConfessionInternalId === null)
+    AssertionError.throwNew('invalid resend confession row: approved title owner missing');
+  if (row.approvedThreadTitle === null)
+    AssertionError.throwNew('invalid resend confession row: approved thread title missing');
   return {
     id: row.pendingChannelThreadId,
-    title: row.threadTitle,
+    title: row.approvedThreadTitle,
     parentMessageId: row.threadParentMessageId,
     approved: {
       threadId: row.approvedThreadId,
@@ -178,11 +194,31 @@ export async function loadResendConfession(db: Interface, channelId: bigint, con
       'confession.id': confessionId.toString(),
     });
 
+    const requestedTitle = aliasedTable(schema.pendingChannelThreadTitle, 'requested_title');
+    const approvedTitle = aliasedTable(schema.pendingChannelThreadTitle, 'approved_title');
+    const approvedThreadForPending = db
+      .select({
+        approvedPendingChannelThreadId: approvedTitle.pendingChannelThreadId,
+        approvedThreadTitle: approvedTitle.title,
+        approvedThreadTitleConfessionInternalId:
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+        approvedThreadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.approvedChannelThread)
+      .innerJoin(
+        approvedTitle,
+        eq(
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          approvedTitle.confessionInternalId,
+        ),
+      )
+      .as('approved_thread_for_pending');
+
     const row = await db
       .select({
         confessionId: schema.confession.confessionId,
         channelId: schema.confession.channelId,
-        pendingChannelThreadId: schema.confession.pendingChannelThreadId,
+        pendingChannelThreadId: requestedTitle.pendingChannelThreadId,
         authorId: schema.confession.authorId,
         content: schema.confession.content,
         createdAt: schema.confession.createdAt,
@@ -193,10 +229,13 @@ export async function loadResendConfession(db: Interface, channelId: bigint, con
         color: schema.channel.color,
         logChannelId: schema.channel.logChannelId,
         threadPendingChannelThreadId: schema.pendingChannelThread.id,
-        threadTitle: schema.pendingChannelThread.title,
+        requestedThreadTitle: requestedTitle.title,
         threadParentMessageId: schema.pendingChannelThread.parentMessageId,
-        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
-        approvedThreadId: schema.approvedChannelThread.threadId,
+        approvedPendingChannelThreadId: approvedThreadForPending.approvedPendingChannelThreadId,
+        approvedThreadTitle: approvedThreadForPending.approvedThreadTitle,
+        approvedThreadTitleConfessionInternalId:
+          approvedThreadForPending.approvedThreadTitleConfessionInternalId,
+        approvedThreadId: approvedThreadForPending.approvedThreadId,
         attachmentId: schema.ephemeralAttachment.id,
         durableAttachmentId: schema.durableAttachment.id,
         durableAttachmentEphemeralId: schema.durableAttachment.ephemeralAttachmentId,
@@ -210,12 +249,19 @@ export async function loadResendConfession(db: Interface, channelId: bigint, con
       .from(schema.confession)
       .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
       .leftJoin(
-        schema.pendingChannelThread,
-        eq(schema.confession.pendingChannelThreadId, schema.pendingChannelThread.id),
+        requestedTitle,
+        eq(schema.confession.internalId, requestedTitle.confessionInternalId),
       )
       .leftJoin(
-        schema.approvedChannelThread,
-        eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
+        schema.pendingChannelThread,
+        eq(requestedTitle.pendingChannelThreadId, schema.pendingChannelThread.id),
+      )
+      .leftJoin(
+        approvedThreadForPending,
+        eq(
+          requestedTitle.pendingChannelThreadId,
+          approvedThreadForPending.approvedPendingChannelThreadId,
+        ),
       )
       .leftJoin(
         schema.ephemeralAttachment,

--- a/src/lib/server/inngest/functions/process-confession-resend/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-resend/query.ts
@@ -3,49 +3,12 @@ import { and, eq } from 'drizzle-orm';
 import * as schema from '$lib/server/database/models';
 import { AssertionError, assertOptional } from '$lib/assert';
 import type { Interface } from '$lib/server/database';
+import { Tracer } from '$lib/server/telemetry/tracer';
 
-interface DurableAttachmentState {
-  id: bigint;
-  filename: string;
-  contentType: string | null;
-  url: string;
-  proxyUrl: string;
-  height: number | null;
-  width: number | null;
-}
+import type { ResendConfessionState } from './state';
 
-interface AttachmentState {
-  id: bigint;
-  durable: DurableAttachmentState | null;
-}
-
-interface ApprovedThreadState {
-  threadId: bigint;
-}
-
-interface PendingThreadState {
-  id: bigint;
-  title: string;
-  approved: ApprovedThreadState | null;
-}
-
-export interface ResendConfessionState {
-  confessionId: bigint;
-  channelId: bigint;
-  authorId: bigint;
-  content: string;
-  createdAt: Date;
-  approvedAt: Date | null;
-  parentMessageId: bigint | null;
-  channel: {
-    guildId: bigint;
-    label: string;
-    color: string | null;
-    logChannelId: bigint | null;
-  };
-  pendingThread: PendingThreadState | null;
-  attachment: AttachmentState | null;
-}
+const SERVICE_NAME = 'inngest.process-confession-resend.query';
+const tracer = Tracer.byName(SERVICE_NAME);
 
 interface FlatResendConfessionRow {
   confessionId: bigint;
@@ -62,6 +25,7 @@ interface FlatResendConfessionRow {
   logChannelId: bigint | null;
   threadPendingChannelThreadId: bigint | null;
   threadTitle: string | null;
+  threadParentMessageId: bigint | null;
   approvedPendingChannelThreadId: bigint | null;
   approvedThreadId: bigint | null;
   attachmentId: bigint | null;
@@ -95,6 +59,7 @@ type PendingThreadRow = Pick<
   | 'approvedPendingChannelThreadId'
   | 'approvedThreadId'
   | 'pendingChannelThreadId'
+  | 'threadParentMessageId'
   | 'threadPendingChannelThreadId'
   | 'threadTitle'
 >;
@@ -167,6 +132,7 @@ function createPendingThread(row: PendingThreadRow) {
     return {
       id: row.pendingChannelThreadId,
       title: row.threadTitle,
+      parentMessageId: row.threadParentMessageId,
       approved: null,
     };
   }
@@ -178,6 +144,7 @@ function createPendingThread(row: PendingThreadRow) {
   return {
     id: row.pendingChannelThreadId,
     title: row.threadTitle,
+    parentMessageId: row.threadParentMessageId,
     approved: {
       threadId: row.approvedThreadId,
     },
@@ -205,60 +172,69 @@ function createResendConfession(row: FlatResendConfessionRow): ResendConfessionS
 }
 
 export async function loadResendConfession(db: Interface, channelId: bigint, confessionId: bigint) {
-  const row = await db
-    .select({
-      confessionId: schema.confession.confessionId,
-      channelId: schema.confession.channelId,
-      pendingChannelThreadId: schema.confession.pendingChannelThreadId,
-      authorId: schema.confession.authorId,
-      content: schema.confession.content,
-      createdAt: schema.confession.createdAt,
-      approvedAt: schema.confession.approvedAt,
-      parentMessageId: schema.confession.parentMessageId,
-      guildId: schema.channel.guildId,
-      label: schema.channel.label,
-      color: schema.channel.color,
-      logChannelId: schema.channel.logChannelId,
-      threadPendingChannelThreadId: schema.pendingChannelThread.id,
-      threadTitle: schema.pendingChannelThread.title,
-      approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
-      approvedThreadId: schema.approvedChannelThread.threadId,
-      attachmentId: schema.ephemeralAttachment.id,
-      durableAttachmentId: schema.durableAttachment.id,
-      durableAttachmentEphemeralId: schema.durableAttachment.ephemeralAttachmentId,
-      durableAttachmentFilename: schema.durableAttachment.filename,
-      durableAttachmentContentType: schema.durableAttachment.contentType,
-      durableAttachmentUrl: schema.durableAttachment.url,
-      durableAttachmentProxyUrl: schema.durableAttachment.proxyUrl,
-      durableAttachmentHeight: schema.durableAttachment.height,
-      durableAttachmentWidth: schema.durableAttachment.width,
-    })
-    .from(schema.confession)
-    .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
-    .leftJoin(
-      schema.pendingChannelThread,
-      eq(schema.confession.pendingChannelThreadId, schema.pendingChannelThread.id),
-    )
-    .leftJoin(
-      schema.approvedChannelThread,
-      eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
-    )
-    .leftJoin(
-      schema.ephemeralAttachment,
-      eq(schema.confession.internalId, schema.ephemeralAttachment.confessionInternalId),
-    )
-    .leftJoin(
-      schema.durableAttachment,
-      eq(schema.ephemeralAttachment.id, schema.durableAttachment.ephemeralAttachmentId),
-    )
-    .where(
-      and(
-        eq(schema.confession.channelId, channelId),
-        eq(schema.confession.confessionId, confessionId),
-      ),
-    )
-    .limit(1)
-    .then(assertOptional);
-  if (typeof row === 'undefined') return;
-  return createResendConfession(row);
+  return await tracer.asyncSpan('load-resend-confession', async span => {
+    span.setAttributes({
+      'channel.id': channelId.toString(),
+      'confession.id': confessionId.toString(),
+    });
+
+    const row = await db
+      .select({
+        confessionId: schema.confession.confessionId,
+        channelId: schema.confession.channelId,
+        pendingChannelThreadId: schema.confession.pendingChannelThreadId,
+        authorId: schema.confession.authorId,
+        content: schema.confession.content,
+        createdAt: schema.confession.createdAt,
+        approvedAt: schema.confession.approvedAt,
+        parentMessageId: schema.confession.parentMessageId,
+        guildId: schema.channel.guildId,
+        label: schema.channel.label,
+        color: schema.channel.color,
+        logChannelId: schema.channel.logChannelId,
+        threadPendingChannelThreadId: schema.pendingChannelThread.id,
+        threadTitle: schema.pendingChannelThread.title,
+        threadParentMessageId: schema.pendingChannelThread.parentMessageId,
+        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        approvedThreadId: schema.approvedChannelThread.threadId,
+        attachmentId: schema.ephemeralAttachment.id,
+        durableAttachmentId: schema.durableAttachment.id,
+        durableAttachmentEphemeralId: schema.durableAttachment.ephemeralAttachmentId,
+        durableAttachmentFilename: schema.durableAttachment.filename,
+        durableAttachmentContentType: schema.durableAttachment.contentType,
+        durableAttachmentUrl: schema.durableAttachment.url,
+        durableAttachmentProxyUrl: schema.durableAttachment.proxyUrl,
+        durableAttachmentHeight: schema.durableAttachment.height,
+        durableAttachmentWidth: schema.durableAttachment.width,
+      })
+      .from(schema.confession)
+      .innerJoin(schema.channel, eq(schema.confession.channelId, schema.channel.id))
+      .leftJoin(
+        schema.pendingChannelThread,
+        eq(schema.confession.pendingChannelThreadId, schema.pendingChannelThread.id),
+      )
+      .leftJoin(
+        schema.approvedChannelThread,
+        eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
+      )
+      .leftJoin(
+        schema.ephemeralAttachment,
+        eq(schema.confession.internalId, schema.ephemeralAttachment.confessionInternalId),
+      )
+      .leftJoin(
+        schema.durableAttachment,
+        eq(schema.ephemeralAttachment.id, schema.durableAttachment.ephemeralAttachmentId),
+      )
+      .where(
+        and(
+          eq(schema.confession.channelId, channelId),
+          eq(schema.confession.confessionId, confessionId),
+        ),
+      )
+      .limit(1)
+      .then(assertOptional);
+    if (typeof row === 'undefined') return;
+
+    return createResendConfession(row);
+  });
 }

--- a/src/lib/server/inngest/functions/process-confession-resend/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-resend/query.ts
@@ -200,17 +200,13 @@ export async function loadResendConfession(db: Interface, channelId: bigint, con
       .select({
         approvedPendingChannelThreadId: approvedTitle.pendingChannelThreadId,
         approvedThreadTitle: approvedTitle.title,
-        approvedThreadTitleConfessionInternalId:
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+        approvedThreadTitleConfessionInternalId: schema.approvedChannelThread.confessionInternalId,
         approvedThreadId: schema.approvedChannelThread.threadId,
       })
       .from(schema.approvedChannelThread)
       .innerJoin(
         approvedTitle,
-        eq(
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
-          approvedTitle.confessionInternalId,
-        ),
+        eq(schema.approvedChannelThread.confessionInternalId, approvedTitle.confessionInternalId),
       )
       .as('approved_thread_for_pending');
 

--- a/src/lib/server/inngest/functions/process-confession-resend/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-resend/query.ts
@@ -159,7 +159,7 @@ function createPendingThread(row: PendingThreadRow) {
     AssertionError.throwNew('invalid resend confession row: approved thread title missing');
   return {
     id: row.pendingChannelThreadId,
-    title: row.approvedThreadTitle,
+    title: row.requestedThreadTitle,
     parentMessageId: row.threadParentMessageId,
     approved: {
       threadId: row.approvedThreadId,

--- a/src/lib/server/inngest/functions/process-confession-resend/state.ts
+++ b/src/lib/server/inngest/functions/process-confession-resend/state.ts
@@ -4,6 +4,7 @@ export interface SerializedConfessionForResend {
   confessionId: string;
   channelId: string;
   pendingChannelThreadId: string | null;
+  pendingThreadTitle: string | null;
   publishChannelId: string;
   authorId: string;
   content: string;
@@ -135,12 +136,21 @@ function serializeResendConfession(
   >,
 ): SerializedConfessionForResend {
   const { pendingThread } = confession;
-  const approvedThread = pendingThread?.approved ?? null;
+
+  let pendingChannelThreadId: string | null = null;
+  let pendingThreadTitle: string | null = null;
+  let approvedThread: ApprovedThreadState | null = null;
+  if (pendingThread !== null) {
+    pendingChannelThreadId = pendingThread.id.toString();
+    pendingThreadTitle = pendingThread.title;
+    approvedThread = pendingThread.approved;
+  }
 
   return {
     confessionId: confession.confessionId.toString(),
     channelId: confession.channelId.toString(),
-    pendingChannelThreadId: pendingThread?.id.toString() ?? null,
+    pendingChannelThreadId,
+    pendingThreadTitle,
     publishChannelId: approvedThread?.threadId.toString() ?? confession.channelId.toString(),
     authorId: confession.authorId.toString(),
     content: confession.content,

--- a/src/lib/server/inngest/functions/process-confession-resend/state.ts
+++ b/src/lib/server/inngest/functions/process-confession-resend/state.ts
@@ -1,7 +1,5 @@
 import type { SerializedAttachment } from '$lib/server/confession';
 
-import type { ResendConfessionState } from './query';
-
 export interface SerializedConfessionForResend {
   confessionId: string;
   channelId: string;
@@ -22,6 +20,50 @@ export interface SerializedConfessionForResend {
     title: string;
   } | null;
   attachment: SerializedAttachment | null;
+}
+
+interface DurableAttachmentState {
+  id: bigint;
+  filename: string;
+  contentType: string | null;
+  url: string;
+  proxyUrl: string;
+  height: number | null;
+  width: number | null;
+}
+
+interface AttachmentState {
+  id: bigint;
+  durable: DurableAttachmentState | null;
+}
+
+interface ApprovedThreadState {
+  threadId: bigint;
+}
+
+interface PendingThreadState {
+  id: bigint;
+  title: string;
+  parentMessageId: bigint | null;
+  approved: ApprovedThreadState | null;
+}
+
+export interface ResendConfessionState {
+  confessionId: bigint;
+  channelId: bigint;
+  authorId: bigint;
+  content: string;
+  createdAt: Date;
+  approvedAt: Date | null;
+  parentMessageId: bigint | null;
+  channel: {
+    guildId: bigint;
+    label: string;
+    color: string | null;
+    logChannelId: bigint | null;
+  };
+  pendingThread: PendingThreadState | null;
+  attachment: AttachmentState | null;
 }
 
 type ResendConfessionSource = Pick<

--- a/src/lib/server/inngest/functions/process-confession-submission/index.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/index.ts
@@ -1,5 +1,3 @@
-import assert from 'node:assert/strict';
-
 import { NonRetriableError } from 'inngest';
 
 import {
@@ -28,6 +26,7 @@ import { Tracer } from '$lib/server/telemetry/tracer';
 import {
   assertConfessionSubmissionChannel,
   createPublicConfession,
+  FatalConfessionSubmissionStateError,
   type LogConfessionResult,
   mapConfessionSubmissionChannel,
   type SerializedConfessionForProcess,
@@ -37,7 +36,6 @@ import {
 import { ConfessionSubmitEvent, ConfessionSubmitMode } from './schema';
 import {
   createConfessionSubmission,
-  ensureExistingThreadRegistration,
   loadApprovedThreadTitle,
   loadConfessionSubmissionChannel,
 } from './query';
@@ -94,16 +92,8 @@ export const processConfessionSubmission = inngest.createFunction(
 
           switch (data.mode) {
             case ConfessionSubmitMode.Message:
-              if (data.threadId !== null) {
-                if (data.threadTitle === null)
-                  return 'Spectro cannot submit confessions in this thread without a thread name.';
-                const { channelId, threadId, threadTitle } = data;
-                return await db.transaction(
-                  async tx =>
-                    await ensureExistingThreadRegistration(tx, channelId, threadId, threadTitle),
-                  { isolationLevel: 'read committed' },
-                );
-              }
+              if (data.threadId !== null && data.threadTitle === null)
+                return 'Spectro cannot submit confessions in this thread without a thread name.';
             // falls through
             case ConfessionSubmitMode.NewThread:
             case ConfessionSubmitMode.NewThreadReply:
@@ -177,6 +167,23 @@ export const processConfessionSubmission = inngest.createFunction(
               throw new NonRetriableError('unknown confession submission mode');
           }
 
+          let newThreadTitle: string | null = null;
+          switch (data.mode) {
+            case ConfessionSubmitMode.NewThread:
+            case ConfessionSubmitMode.NewThreadReply:
+              newThreadTitle = data.threadTitle;
+            // falls through
+            default:
+              break;
+          }
+
+          let existingThreadId: bigint | null = null;
+          let existingThreadTitle: string | null = null;
+          if (threadId !== null) {
+            existingThreadId = BigInt(threadId);
+            existingThreadTitle = data.threadTitle;
+          }
+
           const { internalId, confessionId, pendingThread } = await db.transaction(
             async tx =>
               await createConfessionSubmission(tx, {
@@ -188,12 +195,9 @@ export const processConfessionSubmission = inngest.createFunction(
                 isApprovalRequired: channel.isApprovalRequired,
                 parentMessageId: parentMessageId === null ? null : BigInt(parentMessageId),
                 attachment: serializeRequestedAttachment(data.attachment),
-                newThreadTitle:
-                  data.mode === ConfessionSubmitMode.NewThread ||
-                  data.mode === ConfessionSubmitMode.NewThreadReply
-                    ? data.threadTitle
-                    : null,
-                existingThreadId: threadId === null ? null : BigInt(threadId),
+                newThreadTitle,
+                existingThreadId,
+                existingThreadTitle,
               }),
             { isolationLevel: 'read committed' },
           );
@@ -247,8 +251,9 @@ export const processConfessionSubmission = inngest.createFunction(
       );
 
       let preparedConfession = createdConfession;
+      const { pendingChannelThreadId } = createdConfession;
       if (
-        createdConfession.pendingChannelThreadId !== null &&
+        pendingChannelThreadId !== null &&
         createdConfession.thread === null &&
         createdConfession.approvedAt !== null
       ) {
@@ -351,9 +356,6 @@ export const processConfessionSubmission = inngest.createFunction(
           return;
         }
 
-        const { pendingChannelThreadId } = createdConfession;
-        assert(pendingChannelThreadId !== null);
-
         const threadId = await step.run(
           { id: 'resolve-approved-thread', name: 'Resolve Approved Thread' },
           async () => {
@@ -361,8 +363,8 @@ export const processConfessionSubmission = inngest.createFunction(
               async tx =>
                 await resolveApprovedChannelThread(
                   tx,
-                  BigInt(pendingChannelThreadId),
                   BigInt(threadResult.threadId),
+                  BigInt(createdConfession.internalId),
                 ),
               { isolationLevel: 'read committed' },
             );
@@ -464,13 +466,18 @@ export const processConfessionSubmission = inngest.createFunction(
             });
             return {
               logged: true,
+              attachmentId: null,
               durableAttachment: null,
             };
           }
 
           const uploadedAttachment = preparedConfession.attachment;
           const uploadedAttachmentUrl = parseDiscordAttachmentCdnUrl(uploadedAttachment.url);
-          assert(uploadedAttachmentUrl !== null);
+          if (uploadedAttachmentUrl === null)
+            FatalConfessionSubmissionStateError.throwNew('uploaded attachment url invalid', {
+              'attachment.id': uploadedAttachment.id,
+              'attachment.url': uploadedAttachment.url,
+            });
 
           const response = await fetch(uploadedAttachment.url);
           const file = await downloadDiscordAttachment(response, DISCORD_ATTACHMENT_MAX_BYTES);
@@ -565,6 +572,7 @@ export const processConfessionSubmission = inngest.createFunction(
 
           return {
             logged: true,
+            attachmentId: uploadedAttachment.id,
             durableAttachment,
           };
         },
@@ -617,18 +625,19 @@ export const processConfessionSubmission = inngest.createFunction(
       }
 
       const { durableAttachment } = logResult;
-      if (durableAttachment !== null) {
-        const { attachment } = preparedConfession;
-        assert(attachment !== null);
+      if (durableAttachment !== null)
         await step.run(
           {
             id: 'persist-durable-attachment',
             name: 'Persist Durable Attachment',
           },
           async () =>
-            await upsertDurableAttachmentData(db, BigInt(attachment.id), durableAttachment),
+            await upsertDurableAttachmentData(
+              db,
+              BigInt(logResult.attachmentId),
+              durableAttachment,
+            ),
         );
-      }
 
       if (preparedConfession.approvedAt === null) {
         await step.run(

--- a/src/lib/server/inngest/functions/process-confession-submission/index.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/index.ts
@@ -10,7 +10,12 @@ import {
   getThreadCreationErrorMessage,
   LogPayloadType,
 } from '$lib/server/confession';
-import { db, resetLogChannel, upsertDurableAttachmentData } from '$lib/server/database';
+import {
+  db,
+  resetLogChannel,
+  resolveApprovedChannelThread,
+  upsertDurableAttachmentData,
+} from '$lib/server/database';
 import { DiscordClient } from '$lib/server/api/discord';
 import { DiscordError, DiscordErrorCode } from '$lib/server/models/discord/errors';
 import { extractDurableAttachmentMetadata } from '$lib/server/attachment';
@@ -33,7 +38,6 @@ import { ConfessionSubmitEvent, ConfessionSubmitMode } from './schema';
 import {
   createConfessionSubmission,
   ensureExistingThreadRegistration,
-  insertApprovedChannelThread,
   loadApprovedThreadTitle,
   loadConfessionSubmissionChannel,
 } from './query';
@@ -44,6 +48,18 @@ const logger = Logger.byName(SERVICE_NAME);
 const tracer = Tracer.byName(SERVICE_NAME);
 
 const DISCORD_ATTACHMENT_MAX_BYTES = 8 * 1024 * 1024;
+
+interface CreatedThreadResult {
+  ok: true;
+  threadId: string;
+}
+
+interface FailedThreadCreationResult {
+  ok: false;
+  content: string;
+}
+
+type ThreadCreationResult = CreatedThreadResult | FailedThreadCreationResult;
 
 export const processConfessionSubmission = inngest.createFunction(
   {
@@ -74,7 +90,6 @@ export const processConfessionSubmission = inngest.createFunction(
             await loadConfessionSubmissionChannel(db, BigInt(data.channelId)),
             submittedAt,
           );
-
           if (typeof channel === 'string') return channel;
 
           switch (data.mode) {
@@ -85,22 +100,13 @@ export const processConfessionSubmission = inngest.createFunction(
                 const { channelId, threadId, threadTitle } = data;
                 return await db.transaction(
                   async tx =>
-                    await ensureExistingThreadRegistration(
-                      tx,
-                      channel.isApprovalRequired,
-                      channelId,
-                      threadId,
-                      threadTitle,
-                    ),
+                    await ensureExistingThreadRegistration(tx, channelId, threadId, threadTitle),
                   { isolationLevel: 'read committed' },
                 );
               }
-              break;
+            // falls through
             case ConfessionSubmitMode.NewThread:
-              break;
             case ConfessionSubmitMode.NewThreadReply:
-              if (channel.isApprovalRequired)
-                return 'This channel requires moderator approval, so Spectro cannot create an anonymous reply thread here yet.';
               break;
             default:
               throw new NonRetriableError('unknown confession submission mode');
@@ -171,7 +177,7 @@ export const processConfessionSubmission = inngest.createFunction(
               throw new NonRetriableError('unknown confession submission mode');
           }
 
-          const { internalId, confessionId, pendingChannelThreadId } = await db.transaction(
+          const { internalId, confessionId, pendingThread } = await db.transaction(
             async tx =>
               await createConfessionSubmission(tx, {
                 createdAt,
@@ -192,22 +198,26 @@ export const processConfessionSubmission = inngest.createFunction(
             { isolationLevel: 'read committed' },
           );
 
-          const publishChannelId = threadId ?? data.channelId;
-          let thread = null;
-          if (threadId !== null) {
-            const title = await loadApprovedThreadTitle(
-              db,
-              BigInt(data.channelId),
-              BigInt(threadId),
-            );
-            thread = { id: threadId, title };
+          let publishChannelId = data.channelId;
+          let pendingChannelThreadId: string | null = null;
+          let thread: SerializedConfessionForProcess['thread'] = null;
+          if (pendingThread !== null) {
+            pendingChannelThreadId = pendingThread.id.toString();
+            const { approved } = pendingThread;
+            if (approved !== null) {
+              publishChannelId = approved.threadId.toString();
+              thread = {
+                id: approved.threadId.toString(),
+                title: pendingThread.title,
+              };
+            }
           }
 
           return {
             internalId: internalId.toString(),
             confessionId: confessionId.toString(),
             channelId: data.channelId,
-            pendingChannelThreadId: pendingChannelThreadId?.toString() ?? null,
+            pendingChannelThreadId,
             publishChannelId,
             authorId: data.authorId,
             content: data.content,
@@ -238,53 +248,63 @@ export const processConfessionSubmission = inngest.createFunction(
 
       let preparedConfession = createdConfession;
       if (
-        (data.mode === ConfessionSubmitMode.NewThread ||
-          data.mode === ConfessionSubmitMode.NewThreadReply) &&
+        createdConfession.pendingChannelThreadId !== null &&
+        createdConfession.thread === null &&
         createdConfession.approvedAt !== null
       ) {
         const threadResult = await step.run(
           { id: 'create-discord-thread', name: 'Create Discord Thread' },
-          async (): Promise<SerializedConfessionForProcess | string> => {
-            assert(createdConfession.pendingChannelThreadId !== null);
-            const { pendingChannelThreadId } = createdConfession;
-
+          async (): Promise<ThreadCreationResult> => {
             try {
-              const thread =
-                data.mode === ConfessionSubmitMode.NewThread
-                  ? await DiscordClient.ENV.createPublicThread(data.channelId, data.threadTitle)
-                  : await DiscordClient.ENV.createPublicThreadFromMessage(
-                      data.channelId,
-                      data.parentMessageId,
-                      data.threadTitle,
-                    );
-
-              await insertApprovedChannelThread(
-                db,
-                BigInt(pendingChannelThreadId),
-                BigInt(thread.id),
-              );
-
-              return {
-                ...createdConfession,
-                publishChannelId: thread.id,
-                thread: {
-                  id: thread.id,
-                  title: data.threadTitle,
-                },
-              };
+              switch (data.mode) {
+                case ConfessionSubmitMode.NewThread: {
+                  const thread = await DiscordClient.ENV.createPublicThread(
+                    data.channelId,
+                    data.threadTitle,
+                  );
+                  return { ok: true, threadId: thread.id };
+                }
+                case ConfessionSubmitMode.NewThreadReply: {
+                  const thread = await DiscordClient.ENV.createPublicThreadFromMessage(
+                    data.channelId,
+                    data.parentMessageId,
+                    data.threadTitle,
+                  );
+                  return { ok: true, threadId: thread.id };
+                }
+                case ConfessionSubmitMode.Message:
+                  throw new NonRetriableError('message submission cannot create thread');
+                default:
+                  throw new NonRetriableError('unknown confession submission mode');
+              }
             } catch (error) {
               if (error instanceof DiscordError)
                 switch (error.code) {
+                  case DiscordErrorCode.ThreadAlreadyCreatedForMessage:
+                    return data.mode === ConfessionSubmitMode.NewThreadReply
+                      ? {
+                          ok: true,
+                          threadId: data.parentMessageId,
+                        }
+                      : {
+                          ok: false,
+                          content: getThreadCreationErrorMessage(error.code, {
+                            label: createdConfession.channel.label,
+                            confessionId: createdConfession.confessionId,
+                          }),
+                        };
                   case DiscordErrorCode.UnknownChannel:
                   case DiscordErrorCode.MissingAccess:
                   case DiscordErrorCode.MissingPermissions:
-                  case DiscordErrorCode.ThreadAlreadyCreatedForMessage:
                   case DiscordErrorCode.ThreadLocked:
                   case DiscordErrorCode.MaxActiveThreadsReached:
-                    return getThreadCreationErrorMessage(error.code, {
-                      label: createdConfession.channel.label,
-                      confessionId: createdConfession.confessionId,
-                    });
+                    return {
+                      ok: false,
+                      content: getThreadCreationErrorMessage(error.code, {
+                        label: createdConfession.channel.label,
+                        confessionId: createdConfession.confessionId,
+                      }),
+                    };
                   default:
                     break;
                 }
@@ -293,7 +313,7 @@ export const processConfessionSubmission = inngest.createFunction(
           },
         );
 
-        if (typeof threadResult === 'string') {
+        if (!threadResult.ok) {
           await step.run(
             {
               id: 'edit-original-interaction-response-after-thread',
@@ -304,9 +324,7 @@ export const processConfessionSubmission = inngest.createFunction(
                 await DiscordClient.editOriginalInteractionResponse(
                   applicationId,
                   interactionToken,
-                  {
-                    content: threadResult,
-                  },
+                  { content: threadResult.content },
                 );
               } catch (cause) {
                 if (cause instanceof DiscordError)
@@ -333,7 +351,38 @@ export const processConfessionSubmission = inngest.createFunction(
           return;
         }
 
-        preparedConfession = threadResult;
+        const { pendingChannelThreadId } = createdConfession;
+        assert(pendingChannelThreadId !== null);
+
+        const threadId = await step.run(
+          { id: 'resolve-approved-thread', name: 'Resolve Approved Thread' },
+          async () => {
+            const approved = await db.transaction(
+              async tx =>
+                await resolveApprovedChannelThread(
+                  tx,
+                  BigInt(pendingChannelThreadId),
+                  BigInt(threadResult.threadId),
+                ),
+              { isolationLevel: 'read committed' },
+            );
+            return approved.threadId.toString();
+          },
+        );
+
+        const title = await step.run(
+          { id: 'load-approved-thread-title', name: 'Load Approved Thread Title' },
+          async () => await loadApprovedThreadTitle(db, BigInt(data.channelId), BigInt(threadId)),
+        );
+
+        preparedConfession = {
+          ...createdConfession,
+          publishChannelId: threadId,
+          thread: {
+            id: threadId,
+            title,
+          },
+        };
       }
 
       const logResult = await step.run(

--- a/src/lib/server/inngest/functions/process-confession-submission/index.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/index.ts
@@ -204,9 +204,11 @@ export const processConfessionSubmission = inngest.createFunction(
 
           let publishChannelId = data.channelId;
           let pendingChannelThreadId: string | null = null;
+          let pendingThreadTitle: string | null = null;
           let thread: SerializedConfessionForProcess['thread'] = null;
           if (pendingThread !== null) {
             pendingChannelThreadId = pendingThread.id.toString();
+            pendingThreadTitle = pendingThread.title;
             const { approved } = pendingThread;
             if (approved !== null) {
               publishChannelId = approved.threadId.toString();
@@ -228,6 +230,7 @@ export const processConfessionSubmission = inngest.createFunction(
             createdAt: createdAt.toISOString(),
             approvedAt: channel.isApprovalRequired ? null : createdAt.toISOString(),
             parentMessageId,
+            pendingThreadTitle,
             channel: {
               guildId: channel.guildId.toString(),
               label: channel.label,
@@ -380,6 +383,7 @@ export const processConfessionSubmission = inngest.createFunction(
         preparedConfession = {
           ...createdConfession,
           publishChannelId: threadId,
+          pendingThreadTitle: title,
           thread: {
             id: threadId,
             title,

--- a/src/lib/server/inngest/functions/process-confession-submission/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/query.ts
@@ -170,10 +170,7 @@ async function loadPendingChannelThreadByReplyTarget(
       .from(schema.approvedChannelThread)
       .innerJoin(
         approvedTitle,
-        eq(
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
-          approvedTitle.confessionInternalId,
-        ),
+        eq(schema.approvedChannelThread.confessionInternalId, approvedTitle.confessionInternalId),
       )
       .as('approved_thread_for_pending');
 
@@ -226,7 +223,7 @@ async function loadPendingChannelThreadForApprovedThread(
       .innerJoin(
         schema.pendingChannelThreadTitle,
         eq(
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          schema.approvedChannelThread.confessionInternalId,
           schema.pendingChannelThreadTitle.confessionInternalId,
         ),
       )
@@ -295,7 +292,7 @@ export async function loadApprovedThreadTitle(db: Interface, channelId: bigint, 
       .innerJoin(
         schema.pendingChannelThreadTitle,
         eq(
-          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          schema.approvedChannelThread.confessionInternalId,
           schema.pendingChannelThreadTitle.confessionInternalId,
         ),
       )

--- a/src/lib/server/inngest/functions/process-confession-submission/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/query.ts
@@ -348,11 +348,22 @@ export async function createConfessionSubmission(
         params.newThreadTitle,
       );
 
-      if (pendingThread.approved !== null) return { internalId, confessionId, pendingThread };
+      if (pendingThread.approved !== null)
+        return {
+          internalId,
+          confessionId,
+          pendingThread: {
+            ...pendingThread,
+            title: params.newThreadTitle,
+          },
+        };
       return {
         internalId,
         confessionId,
-        pendingThread: { ...pendingThread, title: params.newThreadTitle },
+        pendingThread: {
+          ...pendingThread,
+          title: params.newThreadTitle,
+        },
       };
     }
 
@@ -372,7 +383,11 @@ export async function createConfessionSubmission(
           existingPendingThread.id,
           params.existingThreadTitle,
         );
-        return { internalId, confessionId, pendingThread: existingPendingThread };
+        return {
+          internalId,
+          confessionId,
+          pendingThread: { ...existingPendingThread, title: params.existingThreadTitle },
+        };
       }
 
       await db.execute(sql`select pg_advisory_xact_lock(${params.existingThreadId})`);
@@ -389,7 +404,14 @@ export async function createConfessionSubmission(
           loadedPendingThread.id,
           params.existingThreadTitle,
         );
-        return { internalId, confessionId, pendingThread: loadedPendingThread };
+        return {
+          internalId,
+          confessionId,
+          pendingThread: {
+            ...loadedPendingThread,
+            title: params.existingThreadTitle,
+          },
+        };
       }
 
       const pendingThread = await insertPendingChannelThread(db, {

--- a/src/lib/server/inngest/functions/process-confession-submission/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/query.ts
@@ -1,11 +1,12 @@
 import { and, eq, sql } from 'drizzle-orm';
 
 import * as schema from '$lib/server/database/models';
-import { assertOptional, assertSingle } from '$lib/assert';
+import { AssertionError, assertDefined, assertOptional, assertSingle } from '$lib/assert';
 import {
   type InsertableAttachment,
   type Interface,
   insertConfession,
+  resolveApprovedChannelThread,
   type Transaction,
 } from '$lib/server/database';
 import { Logger } from '$lib/server/telemetry/logger';
@@ -29,66 +30,36 @@ interface CreateConfessionSubmissionParams {
   existingThreadId: bigint | null;
 }
 
+interface PendingChannelThreadTarget {
+  channelId: bigint;
+  title: string;
+  parentMessageId: bigint | null;
+}
+
+interface FlatPendingChannelThreadRow {
+  pendingChannelThreadId: bigint;
+  title: string;
+  parentMessageId: bigint | null;
+  approvedPendingChannelThreadId: bigint | null;
+  approvedThreadId: bigint | null;
+}
+
 export async function loadConfessionSubmissionChannel(db: Interface, channelId: bigint) {
-  return await db
-    .select({
-      guildId: schema.channel.guildId,
-      logChannelId: schema.channel.logChannelId,
-      disabledAt: schema.channel.disabledAt,
-      isApprovalRequired: schema.channel.isApprovalRequired,
-      label: schema.channel.label,
-      color: schema.channel.color,
-    })
-    .from(schema.channel)
-    .where(eq(schema.channel.id, channelId))
-    .limit(1)
-    .then(assertOptional);
-}
-
-export async function insertPendingChannelThread(db: Interface, channelId: bigint, title: string) {
-  return await tracer.asyncSpan('insert-pending-channel-thread', async span => {
+  return await tracer.asyncSpan('load-confession-submission-channel', async span => {
     span.setAttribute('channel.id', channelId.toString());
-
-    const { id } = await db
-      .insert(schema.pendingChannelThread)
-      .values({
-        channelId,
-        kind: 'new-thread',
-        title,
+    return await db
+      .select({
+        guildId: schema.channel.guildId,
+        logChannelId: schema.channel.logChannelId,
+        disabledAt: schema.channel.disabledAt,
+        isApprovalRequired: schema.channel.isApprovalRequired,
+        label: schema.channel.label,
+        color: schema.channel.color,
       })
-      .returning({ id: schema.pendingChannelThread.id })
-      .then(assertSingle);
-
-    logger.debug('pending channel thread inserted', { 'pending.channel.thread.id': id.toString() });
-    return id;
-  });
-}
-
-export async function insertApprovedChannelThread(
-  db: Interface,
-  pendingChannelThreadId: bigint,
-  threadId: bigint,
-) {
-  return await tracer.asyncSpan('insert-approved-channel-thread', async span => {
-    span.setAttributes({
-      'pending.channel.thread.id': pendingChannelThreadId.toString(),
-      'thread.id': threadId.toString(),
-    });
-
-    const { rowCount } = await db.insert(schema.approvedChannelThread).values({
-      pendingChannelThreadId,
-      threadId,
-    });
-
-    switch (rowCount) {
-      case null:
-        return UnexpectedRowCountDatabaseError.throwNew();
-      case 1:
-        logger.debug('approved channel thread inserted');
-        return;
-      default:
-        return UnexpectedRowCountDatabaseError.throwNew(rowCount);
-    }
+      .from(schema.channel)
+      .where(eq(schema.channel.id, channelId))
+      .limit(1)
+      .then(assertOptional);
   });
 }
 
@@ -102,17 +73,14 @@ async function setConfessionPendingChannelThread(
       'confession.internal.id': internalId.toString(),
       'pending.channel.thread.id': pendingChannelThreadId.toString(),
     });
-
     const { rowCount } = await db
       .update(schema.confession)
       .set({ pendingChannelThreadId })
       .where(eq(schema.confession.internalId, internalId));
-
     switch (rowCount) {
       case null:
         return UnexpectedRowCountDatabaseError.throwNew();
       case 1:
-        logger.debug('confession pending channel thread set');
         return;
       default:
         return UnexpectedRowCountDatabaseError.throwNew(rowCount);
@@ -120,51 +88,196 @@ async function setConfessionPendingChannelThread(
   });
 }
 
-async function loadPendingChannelThreadIdForApprovedThread(
+function createPendingChannelThreadState(row: FlatPendingChannelThreadRow) {
+  if (row.approvedThreadId === null) {
+    if (row.approvedPendingChannelThreadId !== null)
+      AssertionError.throwNew('invalid pending channel thread row: approved owner without thread');
+    return {
+      id: row.pendingChannelThreadId,
+      title: row.title,
+      parentMessageId: row.parentMessageId,
+      approved: null,
+    };
+  }
+
+  if (row.approvedPendingChannelThreadId === null)
+    AssertionError.throwNew('invalid pending channel thread row: approved owner missing');
+  if (row.approvedPendingChannelThreadId !== row.pendingChannelThreadId)
+    AssertionError.throwNew('invalid pending channel thread row: approved owner mismatch');
+
+  return {
+    id: row.pendingChannelThreadId,
+    title: row.title,
+    parentMessageId: row.parentMessageId,
+    approved: { threadId: row.approvedThreadId },
+  };
+}
+
+async function insertPendingChannelThread(db: Interface, target: PendingChannelThreadTarget) {
+  return await tracer.asyncSpan('insert-pending-channel-thread', async span => {
+    span.setAttribute('channel.id', target.channelId.toString());
+    if (target.parentMessageId !== null)
+      span.setAttribute('parent.message.id', target.parentMessageId.toString());
+
+    const kind = target.parentMessageId === null ? 'new-thread' : 'new-thread-reply';
+    const { id } = await db
+      .insert(schema.pendingChannelThread)
+      .values({
+        channelId: target.channelId,
+        kind,
+        parentMessageId: target.parentMessageId,
+        title: target.title,
+      })
+      .returning({ id: schema.pendingChannelThread.id })
+      .then(assertSingle);
+
+    logger.debug('pending channel thread inserted', { 'pending.channel.thread.id': id.toString() });
+
+    return {
+      id,
+      title: target.title,
+      parentMessageId: target.parentMessageId,
+      approved: null,
+    };
+  });
+}
+
+async function loadPendingChannelThreadByReplyTarget(
+  db: Interface,
+  channelId: bigint,
+  parentMessageId: bigint,
+) {
+  return await tracer.asyncSpan('load-pending-channel-thread-by-reply-target', async span => {
+    span.setAttributes({
+      'channel.id': channelId.toString(),
+      'parent.message.id': parentMessageId.toString(),
+    });
+    const row = await db
+      .select({
+        pendingChannelThreadId: schema.pendingChannelThread.id,
+        title: schema.pendingChannelThread.title,
+        parentMessageId: schema.pendingChannelThread.parentMessageId,
+        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        approvedThreadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.pendingChannelThread)
+      .leftJoin(
+        schema.approvedChannelThread,
+        eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
+      )
+      .where(
+        and(
+          eq(schema.pendingChannelThread.channelId, channelId),
+          eq(schema.pendingChannelThread.parentMessageId, parentMessageId),
+        ),
+      )
+      .limit(1)
+      .then(assertOptional);
+    if (typeof row === 'undefined') return;
+    return createPendingChannelThreadState(row);
+  });
+}
+
+async function loadPendingChannelThreadForApprovedThread(
   db: Interface,
   channelId: bigint,
   threadId: bigint,
 ) {
-  const { pendingChannelThreadId } = await db
-    .select({ pendingChannelThreadId: schema.pendingChannelThread.id })
-    .from(schema.approvedChannelThread)
-    .innerJoin(
-      schema.pendingChannelThread,
-      eq(schema.approvedChannelThread.pendingChannelThreadId, schema.pendingChannelThread.id),
-    )
-    .where(
-      and(
-        eq(schema.pendingChannelThread.channelId, channelId),
-        eq(schema.approvedChannelThread.threadId, threadId),
-      ),
-    )
-    .limit(1)
-    .then(assertSingle);
-  return pendingChannelThreadId;
+  return await tracer.asyncSpan('load-pending-channel-thread-for-approved-thread', async span => {
+    span.setAttributes({
+      'channel.id': channelId.toString(),
+      'thread.id': threadId.toString(),
+    });
+
+    const row = await db
+      .select({
+        pendingChannelThreadId: schema.pendingChannelThread.id,
+        title: schema.pendingChannelThread.title,
+        parentMessageId: schema.pendingChannelThread.parentMessageId,
+        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        approvedThreadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.approvedChannelThread)
+      .innerJoin(
+        schema.pendingChannelThread,
+        eq(schema.approvedChannelThread.pendingChannelThreadId, schema.pendingChannelThread.id),
+      )
+      .where(
+        and(
+          eq(schema.pendingChannelThread.channelId, channelId),
+          eq(schema.approvedChannelThread.threadId, threadId),
+        ),
+      )
+      .limit(1)
+      .then(assertOptional);
+    if (typeof row === 'undefined') return;
+
+    return createPendingChannelThreadState(row);
+  });
+}
+
+async function ensurePendingChannelThread(db: Transaction, target: PendingChannelThreadTarget) {
+  return await tracer.asyncSpan('ensure-pending-channel-thread', async span => {
+    span.setAttribute('channel.id', target.channelId.toString());
+    if (target.parentMessageId !== null)
+      span.setAttribute('parent.message.id', target.parentMessageId.toString());
+
+    if (target.parentMessageId !== null) {
+      await db.execute(sql`select pg_advisory_xact_lock(${target.parentMessageId})`);
+
+      const existing = await loadPendingChannelThreadByReplyTarget(
+        db,
+        target.channelId,
+        target.parentMessageId,
+      );
+      if (typeof existing !== 'undefined') {
+        logger.debug('found existing thread');
+        return existing;
+      }
+
+      const approved = await loadPendingChannelThreadForApprovedThread(
+        db,
+        target.channelId,
+        target.parentMessageId,
+      );
+      if (typeof approved !== 'undefined') {
+        logger.debug('found approved thread');
+        return approved;
+      }
+    }
+
+    return await insertPendingChannelThread(db, target);
+  });
 }
 
 export async function loadApprovedThreadTitle(db: Interface, channelId: bigint, threadId: bigint) {
-  const { title } = await db
-    .select({ title: schema.pendingChannelThread.title })
-    .from(schema.approvedChannelThread)
-    .innerJoin(
-      schema.pendingChannelThread,
-      eq(schema.approvedChannelThread.pendingChannelThreadId, schema.pendingChannelThread.id),
-    )
-    .where(
-      and(
-        eq(schema.pendingChannelThread.channelId, channelId),
-        eq(schema.approvedChannelThread.threadId, threadId),
-      ),
-    )
-    .limit(1)
-    .then(assertSingle);
-  return title;
+  return await tracer.asyncSpan('load-approved-thread-title', async span => {
+    span.setAttributes({
+      'channel.id': channelId.toString(),
+      'thread.id': threadId.toString(),
+    });
+
+    const { title } = await db
+      .select({ title: schema.pendingChannelThread.title })
+      .from(schema.approvedChannelThread)
+      .innerJoin(
+        schema.pendingChannelThread,
+        eq(schema.approvedChannelThread.pendingChannelThreadId, schema.pendingChannelThread.id),
+      )
+      .where(
+        and(
+          eq(schema.pendingChannelThread.channelId, channelId),
+          eq(schema.approvedChannelThread.threadId, threadId),
+        ),
+      )
+      .limit(1)
+      .then(assertSingle);
+    return title;
+  });
 }
 
 export async function ensureExistingThreadRegistration(
   db: Transaction,
-  isApprovalRequired: boolean,
   channelId: string,
   threadId: string,
   title: string,
@@ -176,8 +289,6 @@ export async function ensureExistingThreadRegistration(
       title,
     });
 
-    // Acquires advisory lock to prevent race on creating the
-    // same approved channel thread by multiple requests.
     await db.execute(sql`select pg_advisory_xact_lock(${BigInt(threadId)})`);
 
     const existing = await db
@@ -196,14 +307,14 @@ export async function ensureExistingThreadRegistration(
       .limit(1)
       .then(assertOptional);
 
-    if (typeof existing === 'undefined') {
-      // TODO: Eventually allow approval-required channels with thread creation.
-      if (isApprovalRequired)
-        return 'This channel requires moderator approval, so Spectro cannot register existing threads for anonymous confessions here.';
-      const pendingChannelThreadId = await insertPendingChannelThread(db, BigInt(channelId), title);
-      await insertApprovedChannelThread(db, pendingChannelThreadId, BigInt(threadId));
-    }
+    if (typeof existing !== 'undefined') return null;
 
+    const pending = await insertPendingChannelThread(db, {
+      channelId: BigInt(channelId),
+      title,
+      parentMessageId: null,
+    });
+    await resolveApprovedChannelThread(db, pending.id, BigInt(threadId));
     return null;
   });
 }
@@ -212,38 +323,48 @@ export async function createConfessionSubmission(
   db: Transaction,
   params: CreateConfessionSubmissionParams,
 ) {
-  const { internalId, confessionId } = await insertConfession(
-    db,
-    params.createdAt,
-    params.guildId,
-    params.channelId,
-    params.authorId,
-    params.content,
-    params.isApprovalRequired ? null : params.createdAt,
-    params.parentMessageId,
-    params.attachment,
-  );
+  return await tracer.asyncSpan('create-confession-submission', async span => {
+    span.setAttributes({
+      'channel.id': params.channelId.toString(),
+      'author.id': params.authorId.toString(),
+      'parent.message.id': params.parentMessageId?.toString(),
+      'existing.thread.id': params.existingThreadId?.toString(),
+    });
 
-  if (params.newThreadTitle !== null) {
-    const pendingChannelThreadId = await insertPendingChannelThread(
+    const { internalId, confessionId } = await insertConfession(
       db,
+      params.createdAt,
+      params.guildId,
       params.channelId,
-      params.newThreadTitle,
-    );
-    await setConfessionPendingChannelThread(db, internalId, pendingChannelThreadId);
-    return { internalId, confessionId, pendingChannelThreadId };
-  }
-
-  if (params.existingThreadId !== null) {
-    const pendingChannelThreadId = await loadPendingChannelThreadIdForApprovedThread(
-      db,
-      params.channelId,
-      params.existingThreadId,
+      params.authorId,
+      params.content,
+      params.isApprovalRequired ? null : params.createdAt,
+      params.parentMessageId,
+      params.attachment,
     );
 
-    await setConfessionPendingChannelThread(db, internalId, pendingChannelThreadId);
-    return { internalId, confessionId, pendingChannelThreadId };
-  }
+    if (params.newThreadTitle !== null) {
+      const pendingThread = await ensurePendingChannelThread(db, {
+        channelId: params.channelId,
+        title: params.newThreadTitle,
+        parentMessageId: params.parentMessageId,
+      });
+      await setConfessionPendingChannelThread(db, internalId, pendingThread.id);
+      return { internalId, confessionId, pendingThread };
+    }
 
-  return { internalId, confessionId, pendingChannelThreadId: null };
+    if (params.existingThreadId !== null) {
+      const pendingThread = assertDefined(
+        await loadPendingChannelThreadForApprovedThread(
+          db,
+          params.channelId,
+          params.existingThreadId,
+        ),
+      );
+      await setConfessionPendingChannelThread(db, internalId, pendingThread.id);
+      return { internalId, confessionId, pendingThread };
+    }
+
+    return { internalId, confessionId, pendingThread: null };
+  });
 }

--- a/src/lib/server/inngest/functions/process-confession-submission/query.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/query.ts
@@ -1,7 +1,7 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { aliasedTable, and, eq, sql } from 'drizzle-orm';
 
 import * as schema from '$lib/server/database/models';
-import { AssertionError, assertDefined, assertOptional, assertSingle } from '$lib/assert';
+import { AssertionError, assertOptional, assertSingle } from '$lib/assert';
 import {
   type InsertableAttachment,
   type Interface,
@@ -28,19 +28,19 @@ interface CreateConfessionSubmissionParams {
   attachment: InsertableAttachment | null;
   newThreadTitle: string | null;
   existingThreadId: bigint | null;
+  existingThreadTitle: string | null;
 }
 
 interface PendingChannelThreadTarget {
   channelId: bigint;
-  title: string;
   parentMessageId: bigint | null;
 }
 
 interface FlatPendingChannelThreadRow {
   pendingChannelThreadId: bigint;
-  title: string;
   parentMessageId: bigint | null;
   approvedPendingChannelThreadId: bigint | null;
+  approvedTitle: string | null;
   approvedThreadId: bigint | null;
 }
 
@@ -63,38 +63,14 @@ export async function loadConfessionSubmissionChannel(db: Interface, channelId: 
   });
 }
 
-async function setConfessionPendingChannelThread(
-  db: Interface,
-  internalId: bigint,
-  pendingChannelThreadId: bigint,
-) {
-  return await tracer.asyncSpan('set-confession-pending-channel-thread', async span => {
-    span.setAttributes({
-      'confession.internal.id': internalId.toString(),
-      'pending.channel.thread.id': pendingChannelThreadId.toString(),
-    });
-    const { rowCount } = await db
-      .update(schema.confession)
-      .set({ pendingChannelThreadId })
-      .where(eq(schema.confession.internalId, internalId));
-    switch (rowCount) {
-      case null:
-        return UnexpectedRowCountDatabaseError.throwNew();
-      case 1:
-        return;
-      default:
-        return UnexpectedRowCountDatabaseError.throwNew(rowCount);
-    }
-  });
-}
-
 function createPendingChannelThreadState(row: FlatPendingChannelThreadRow) {
   if (row.approvedThreadId === null) {
     if (row.approvedPendingChannelThreadId !== null)
       AssertionError.throwNew('invalid pending channel thread row: approved owner without thread');
+    if (row.approvedTitle !== null)
+      AssertionError.throwNew('invalid pending channel thread row: approved title without thread');
     return {
       id: row.pendingChannelThreadId,
-      title: row.title,
       parentMessageId: row.parentMessageId,
       approved: null,
     };
@@ -104,10 +80,12 @@ function createPendingChannelThreadState(row: FlatPendingChannelThreadRow) {
     AssertionError.throwNew('invalid pending channel thread row: approved owner missing');
   if (row.approvedPendingChannelThreadId !== row.pendingChannelThreadId)
     AssertionError.throwNew('invalid pending channel thread row: approved owner mismatch');
+  if (row.approvedTitle === null)
+    AssertionError.throwNew('invalid pending channel thread row: approved title missing');
 
   return {
     id: row.pendingChannelThreadId,
-    title: row.title,
+    title: row.approvedTitle,
     parentMessageId: row.parentMessageId,
     approved: { threadId: row.approvedThreadId },
   };
@@ -126,7 +104,6 @@ async function insertPendingChannelThread(db: Interface, target: PendingChannelT
         channelId: target.channelId,
         kind,
         parentMessageId: target.parentMessageId,
-        title: target.title,
       })
       .returning({ id: schema.pendingChannelThread.id })
       .then(assertSingle);
@@ -135,10 +112,40 @@ async function insertPendingChannelThread(db: Interface, target: PendingChannelT
 
     return {
       id,
-      title: target.title,
       parentMessageId: target.parentMessageId,
       approved: null,
     };
+  });
+}
+
+async function insertPendingChannelThreadTitle(
+  db: Interface,
+  confessionInternalId: bigint,
+  pendingChannelThreadId: bigint,
+  title: string,
+) {
+  return await tracer.asyncSpan('insert-pending-channel-thread-title', async span => {
+    span.setAttributes({
+      'confession.internal.id': confessionInternalId.toString(),
+      'pending.channel.thread.id': pendingChannelThreadId.toString(),
+      title,
+    });
+
+    const { rowCount } = await db.insert(schema.pendingChannelThreadTitle).values({
+      confessionInternalId,
+      pendingChannelThreadId,
+      title,
+    });
+
+    switch (rowCount) {
+      case null:
+        return UnexpectedRowCountDatabaseError.throwNew();
+      case 1:
+        logger.debug('pending channel thread title inserted');
+        return;
+      default:
+        return UnexpectedRowCountDatabaseError.throwNew(rowCount);
+    }
   });
 }
 
@@ -152,18 +159,36 @@ async function loadPendingChannelThreadByReplyTarget(
       'channel.id': channelId.toString(),
       'parent.message.id': parentMessageId.toString(),
     });
+
+    const approvedTitle = aliasedTable(schema.pendingChannelThreadTitle, 'approved_title');
+    const approvedThreadForPending = db
+      .select({
+        approvedPendingChannelThreadId: approvedTitle.pendingChannelThreadId,
+        approvedTitle: approvedTitle.title,
+        approvedThreadId: schema.approvedChannelThread.threadId,
+      })
+      .from(schema.approvedChannelThread)
+      .innerJoin(
+        approvedTitle,
+        eq(
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          approvedTitle.confessionInternalId,
+        ),
+      )
+      .as('approved_thread_for_pending');
+
     const row = await db
       .select({
         pendingChannelThreadId: schema.pendingChannelThread.id,
-        title: schema.pendingChannelThread.title,
         parentMessageId: schema.pendingChannelThread.parentMessageId,
-        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
-        approvedThreadId: schema.approvedChannelThread.threadId,
+        approvedPendingChannelThreadId: approvedThreadForPending.approvedPendingChannelThreadId,
+        approvedTitle: approvedThreadForPending.approvedTitle,
+        approvedThreadId: approvedThreadForPending.approvedThreadId,
       })
       .from(schema.pendingChannelThread)
       .leftJoin(
-        schema.approvedChannelThread,
-        eq(schema.pendingChannelThread.id, schema.approvedChannelThread.pendingChannelThreadId),
+        approvedThreadForPending,
+        eq(schema.pendingChannelThread.id, approvedThreadForPending.approvedPendingChannelThreadId),
       )
       .where(
         and(
@@ -191,16 +216,23 @@ async function loadPendingChannelThreadForApprovedThread(
 
     const row = await db
       .select({
-        pendingChannelThreadId: schema.pendingChannelThread.id,
-        title: schema.pendingChannelThread.title,
+        pendingChannelThreadId: schema.pendingChannelThreadTitle.pendingChannelThreadId,
+        approvedTitle: schema.pendingChannelThreadTitle.title,
         parentMessageId: schema.pendingChannelThread.parentMessageId,
-        approvedPendingChannelThreadId: schema.approvedChannelThread.pendingChannelThreadId,
+        approvedPendingChannelThreadId: schema.pendingChannelThreadTitle.pendingChannelThreadId,
         approvedThreadId: schema.approvedChannelThread.threadId,
       })
       .from(schema.approvedChannelThread)
       .innerJoin(
+        schema.pendingChannelThreadTitle,
+        eq(
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          schema.pendingChannelThreadTitle.confessionInternalId,
+        ),
+      )
+      .innerJoin(
         schema.pendingChannelThread,
-        eq(schema.approvedChannelThread.pendingChannelThreadId, schema.pendingChannelThread.id),
+        eq(schema.pendingChannelThreadTitle.pendingChannelThreadId, schema.pendingChannelThread.id),
       )
       .where(
         and(
@@ -258,11 +290,18 @@ export async function loadApprovedThreadTitle(db: Interface, channelId: bigint, 
     });
 
     const { title } = await db
-      .select({ title: schema.pendingChannelThread.title })
+      .select({ title: schema.pendingChannelThreadTitle.title })
       .from(schema.approvedChannelThread)
       .innerJoin(
+        schema.pendingChannelThreadTitle,
+        eq(
+          schema.approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          schema.pendingChannelThreadTitle.confessionInternalId,
+        ),
+      )
+      .innerJoin(
         schema.pendingChannelThread,
-        eq(schema.approvedChannelThread.pendingChannelThreadId, schema.pendingChannelThread.id),
+        eq(schema.pendingChannelThreadTitle.pendingChannelThreadId, schema.pendingChannelThread.id),
       )
       .where(
         and(
@@ -273,49 +312,6 @@ export async function loadApprovedThreadTitle(db: Interface, channelId: bigint, 
       .limit(1)
       .then(assertSingle);
     return title;
-  });
-}
-
-export async function ensureExistingThreadRegistration(
-  db: Transaction,
-  channelId: string,
-  threadId: string,
-  title: string,
-) {
-  return await tracer.asyncSpan('ensure-existing-thread-registration', async span => {
-    span.setAttributes({
-      'channel.id': channelId,
-      'thread.id': threadId,
-      title,
-    });
-
-    await db.execute(sql`select pg_advisory_xact_lock(${BigInt(threadId)})`);
-
-    const existing = await db
-      .select({ pendingChannelThreadId: schema.pendingChannelThread.id })
-      .from(schema.approvedChannelThread)
-      .innerJoin(
-        schema.pendingChannelThread,
-        eq(schema.approvedChannelThread.pendingChannelThreadId, schema.pendingChannelThread.id),
-      )
-      .where(
-        and(
-          eq(schema.pendingChannelThread.channelId, BigInt(channelId)),
-          eq(schema.approvedChannelThread.threadId, BigInt(threadId)),
-        ),
-      )
-      .limit(1)
-      .then(assertOptional);
-
-    if (typeof existing !== 'undefined') return null;
-
-    const pending = await insertPendingChannelThread(db, {
-      channelId: BigInt(channelId),
-      title,
-      parentMessageId: null,
-    });
-    await resolveApprovedChannelThread(db, pending.id, BigInt(threadId));
-    return null;
   });
 }
 
@@ -346,23 +342,79 @@ export async function createConfessionSubmission(
     if (params.newThreadTitle !== null) {
       const pendingThread = await ensurePendingChannelThread(db, {
         channelId: params.channelId,
-        title: params.newThreadTitle,
         parentMessageId: params.parentMessageId,
       });
-      await setConfessionPendingChannelThread(db, internalId, pendingThread.id);
-      return { internalId, confessionId, pendingThread };
+      await insertPendingChannelThreadTitle(
+        db,
+        internalId,
+        pendingThread.id,
+        params.newThreadTitle,
+      );
+
+      if (pendingThread.approved !== null) return { internalId, confessionId, pendingThread };
+      return {
+        internalId,
+        confessionId,
+        pendingThread: { ...pendingThread, title: params.newThreadTitle },
+      };
     }
 
     if (params.existingThreadId !== null) {
-      const pendingThread = assertDefined(
-        await loadPendingChannelThreadForApprovedThread(
-          db,
-          params.channelId,
-          params.existingThreadId,
-        ),
+      if (params.existingThreadTitle === null)
+        AssertionError.throwNew('existing thread title missing');
+
+      const existingPendingThread = await loadPendingChannelThreadForApprovedThread(
+        db,
+        params.channelId,
+        params.existingThreadId,
       );
-      await setConfessionPendingChannelThread(db, internalId, pendingThread.id);
-      return { internalId, confessionId, pendingThread };
+      if (typeof existingPendingThread !== 'undefined') {
+        await insertPendingChannelThreadTitle(
+          db,
+          internalId,
+          existingPendingThread.id,
+          params.existingThreadTitle,
+        );
+        return { internalId, confessionId, pendingThread: existingPendingThread };
+      }
+
+      await db.execute(sql`select pg_advisory_xact_lock(${params.existingThreadId})`);
+
+      const loadedPendingThread = await loadPendingChannelThreadForApprovedThread(
+        db,
+        params.channelId,
+        params.existingThreadId,
+      );
+      if (typeof loadedPendingThread !== 'undefined') {
+        await insertPendingChannelThreadTitle(
+          db,
+          internalId,
+          loadedPendingThread.id,
+          params.existingThreadTitle,
+        );
+        return { internalId, confessionId, pendingThread: loadedPendingThread };
+      }
+
+      const pendingThread = await insertPendingChannelThread(db, {
+        channelId: params.channelId,
+        parentMessageId: null,
+      });
+      await insertPendingChannelThreadTitle(
+        db,
+        internalId,
+        pendingThread.id,
+        params.existingThreadTitle,
+      );
+      const approved = await resolveApprovedChannelThread(db, params.existingThreadId, internalId);
+      return {
+        internalId,
+        confessionId,
+        pendingThread: {
+          ...pendingThread,
+          title: params.existingThreadTitle,
+          approved: { threadId: approved.threadId },
+        },
+      };
     }
 
     return { internalId, confessionId, pendingThread: null };

--- a/src/lib/server/inngest/functions/process-confession-submission/state.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/state.ts
@@ -78,10 +78,21 @@ export interface FailedLogConfessionResult {
   resetLogChannelId: string | null;
 }
 
-export interface LoggedConfessionResult {
+export interface LoggedConfessionWithoutAttachmentResult {
   logged: true;
-  durableAttachment: PersistableDurableAttachment | null;
+  attachmentId: null;
+  durableAttachment: null;
 }
+
+export interface LoggedConfessionWithAttachmentResult {
+  logged: true;
+  attachmentId: string;
+  durableAttachment: PersistableDurableAttachment;
+}
+
+export type LoggedConfessionResult =
+  | LoggedConfessionWithAttachmentResult
+  | LoggedConfessionWithoutAttachmentResult;
 
 export type LogConfessionResult = FailedLogConfessionResult | LoggedConfessionResult;
 

--- a/src/lib/server/inngest/functions/process-confession-submission/state.ts
+++ b/src/lib/server/inngest/functions/process-confession-submission/state.ts
@@ -38,6 +38,7 @@ export interface SerializedConfessionForProcess {
   createdAt: string;
   approvedAt: string | null;
   parentMessageId: string | null;
+  pendingThreadTitle: string | null;
   channel: {
     guildId: string;
     label: string;
@@ -60,6 +61,7 @@ export interface SerializedConfessionForDispatch {
   content: string;
   createdAt: string;
   parentMessageId: string | null;
+  pendingThreadTitle: string | null;
   channel: {
     guildId: string;
     label: string;
@@ -170,6 +172,7 @@ export function createPublicConfession(
     | 'createdAt'
     | 'parentMessageId'
     | 'pendingChannelThreadId'
+    | 'pendingThreadTitle'
     | 'publishChannelId'
     | 'thread'
   >,
@@ -183,6 +186,7 @@ export function createPublicConfession(
     content: confession.content,
     createdAt: confession.createdAt,
     parentMessageId: confession.parentMessageId,
+    pendingThreadTitle: confession.pendingThreadTitle,
     channel: {
       guildId: confession.channel.guildId,
       label: confession.channel.label,

--- a/src/routes/webhook/discord/interaction/approval.ts
+++ b/src/routes/webhook/discord/interaction/approval.ts
@@ -286,7 +286,7 @@ function createApprovalVerdictThread(row: ApprovalVerdictThreadRow) {
     AssertionError.throwNew('invalid approval verdict row: approved thread title missing');
 
   return {
-    title: row.approvedThreadTitle,
+    title: row.requestedThreadTitle,
     threadId: row.approvedThreadId,
   };
 }

--- a/src/routes/webhook/discord/interaction/approval.ts
+++ b/src/routes/webhook/discord/interaction/approval.ts
@@ -325,10 +325,7 @@ async function loadApprovalVerdictConfession(tx: Transaction, internalId: bigint
       .from(approvedChannelThread)
       .innerJoin(
         approvedTitle,
-        eq(
-          approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
-          approvedTitle.confessionInternalId,
-        ),
+        eq(approvedChannelThread.confessionInternalId, approvedTitle.confessionInternalId),
       )
       .as('approved_thread_for_pending');
 

--- a/src/routes/webhook/discord/interaction/approval.ts
+++ b/src/routes/webhook/discord/interaction/approval.ts
@@ -3,14 +3,15 @@ import assert, { strictEqual } from 'node:assert/strict';
 import { aliasedTable, eq } from 'drizzle-orm';
 
 import { APP_ICON_URL, Color } from '$lib/server/constants';
-import { assertSingle } from '$lib/assert';
 import {
+  approvedChannelThread,
   channel,
   confession,
   durableAttachment,
   ephemeralAttachment,
   pendingChannelThread,
 } from '$lib/server/database/models';
+import { assertSingle } from '$lib/assert';
 import { ConfessionApprovalEvent } from '$lib/server/inngest/functions/dispatch-approval/schema';
 import type { CreateMessageAttachment } from '$lib/server/models/discord/message';
 import { db } from '$lib/server/database';
@@ -157,10 +158,13 @@ async function submitVerdict(
             .select({
               disabledAt: channel.disabledAt,
               label: channel.label,
+              guildId: channel.guildId,
+              channelId: lockedConfession.channelId,
               authorId: lockedConfession.authorId,
               approvedAt: lockedConfession.approvedAt,
               content: lockedConfession.content,
               confessionId: lockedConfession.confessionId,
+              parentMessageId: lockedConfession.parentMessageId,
               ephemeralAttachmentId: ephemeralAttachment.id,
               durableAttachmentId: durableAttachment.id,
               attachmentFilename: durableAttachment.filename,
@@ -169,12 +173,17 @@ async function submitVerdict(
               attachmentHeight: durableAttachment.height,
               attachmentWidth: durableAttachment.width,
               threadTitle: pendingChannelThread.title,
+              threadId: approvedChannelThread.threadId,
             })
             .from(lockedConfession)
             .innerJoin(channel, eq(lockedConfession.channelId, channel.id))
             .leftJoin(
               pendingChannelThread,
               eq(lockedConfession.pendingChannelThreadId, pendingChannelThread.id),
+            )
+            .leftJoin(
+              approvedChannelThread,
+              eq(pendingChannelThread.id, approvedChannelThread.pendingChannelThreadId),
             )
             .leftJoin(
               ephemeralAttachment,
@@ -235,6 +244,19 @@ async function submitVerdict(
             inline: true,
           },
         ];
+
+        if (result.threadTitle !== null) {
+          fields.push({ name: 'Parent Channel', value: `<#${result.channelId}>`, inline: true });
+          if (result.threadId !== null)
+            fields.push({ name: 'Thread Channel', value: `<#${result.threadId}>`, inline: true });
+        }
+
+        if (result.parentMessageId !== null)
+          fields.push({
+            name: 'Reply To',
+            value: `https://discord.com/channels/${result.guildId}/${result.channelId}/${result.parentMessageId}`,
+            inline: true,
+          });
 
         // eslint-disable-next-line @typescript-eslint/init-declarations
         let embed: Embed;

--- a/src/routes/webhook/discord/interaction/approval.ts
+++ b/src/routes/webhook/discord/interaction/approval.ts
@@ -1,4 +1,4 @@
-import assert, { strictEqual } from 'node:assert/strict';
+import { strictEqual } from 'node:assert/strict';
 
 import { aliasedTable, eq } from 'drizzle-orm';
 
@@ -10,11 +10,12 @@ import {
   durableAttachment,
   ephemeralAttachment,
   pendingChannelThread,
+  pendingChannelThreadTitle,
 } from '$lib/server/database/models';
-import { assertSingle } from '$lib/assert';
+import { AssertionError, assertSingle } from '$lib/assert';
 import { ConfessionApprovalEvent } from '$lib/server/inngest/functions/dispatch-approval/schema';
 import type { CreateMessageAttachment } from '$lib/server/models/discord/message';
-import { db } from '$lib/server/database';
+import { db, type Transaction } from '$lib/server/database';
 import { type Embed, EmbedField, EmbedImage, EmbedType } from '$lib/server/models/discord/embed';
 import { hasAllFlags } from '$lib/bits';
 import { inngest } from '$lib/server/inngest/client';
@@ -121,6 +122,281 @@ interface ApprovalVerdictAttachment {
   width: number | null;
 }
 
+interface ApprovalVerdictConfessionAttachment {
+  ephemeralId: bigint;
+  durable: ApprovalVerdictAttachment | null;
+}
+
+interface ApprovalVerdictThread {
+  title: string;
+  threadId: bigint | null;
+}
+
+interface ApprovalVerdictConfession {
+  disabledAt: Date | null;
+  label: string;
+  guildId: bigint;
+  channelId: bigint;
+  authorId: bigint;
+  approvedAt: Date | null;
+  content: string;
+  confessionId: bigint;
+  parentMessageId: bigint | null;
+  thread: ApprovalVerdictThread | null;
+  attachment: ApprovalVerdictConfessionAttachment | null;
+}
+
+interface FlatApprovalVerdictConfessionRow {
+  disabledAt: Date | null;
+  label: string;
+  guildId: bigint;
+  channelId: bigint;
+  authorId: bigint;
+  approvedAt: Date | null;
+  content: string;
+  confessionId: bigint;
+  parentMessageId: bigint | null;
+  ephemeralAttachmentId: bigint | null;
+  durableAttachmentId: bigint | null;
+  attachmentFilename: string | null;
+  attachmentContentType: string | null;
+  attachmentUrl: string | null;
+  attachmentHeight: number | null;
+  attachmentWidth: number | null;
+  pendingChannelThreadId: bigint | null;
+  requestedThreadTitle: string | null;
+  threadPendingChannelThreadId: bigint | null;
+  threadParentMessageId: bigint | null;
+  approvedPendingChannelThreadId: bigint | null;
+  approvedThreadTitle: string | null;
+  approvedThreadId: bigint | null;
+}
+
+type ApprovalVerdictAttachmentRow = Pick<
+  FlatApprovalVerdictConfessionRow,
+  | 'attachmentContentType'
+  | 'attachmentFilename'
+  | 'attachmentHeight'
+  | 'attachmentUrl'
+  | 'attachmentWidth'
+  | 'durableAttachmentId'
+  | 'ephemeralAttachmentId'
+>;
+
+type ApprovalVerdictThreadRow = Pick<
+  FlatApprovalVerdictConfessionRow,
+  | 'approvedPendingChannelThreadId'
+  | 'approvedThreadId'
+  | 'approvedThreadTitle'
+  | 'pendingChannelThreadId'
+  | 'requestedThreadTitle'
+  | 'threadParentMessageId'
+  | 'threadPendingChannelThreadId'
+>;
+
+function createApprovalVerdictAttachment(row: ApprovalVerdictAttachmentRow) {
+  if (row.ephemeralAttachmentId === null) {
+    if (row.durableAttachmentId !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan durable attachment');
+    if (row.attachmentFilename !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan attachment filename');
+    if (row.attachmentContentType !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan attachment content type');
+    if (row.attachmentUrl !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan attachment url');
+    if (row.attachmentHeight !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan attachment height');
+    if (row.attachmentWidth !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan attachment width');
+    return null;
+  }
+
+  if (row.durableAttachmentId === null) {
+    if (row.attachmentFilename !== null)
+      AssertionError.throwNew('invalid approval verdict row: durable filename without id');
+    if (row.attachmentContentType !== null)
+      AssertionError.throwNew('invalid approval verdict row: durable content type without id');
+    if (row.attachmentUrl !== null)
+      AssertionError.throwNew('invalid approval verdict row: durable url without id');
+    if (row.attachmentHeight !== null)
+      AssertionError.throwNew('invalid approval verdict row: durable height without id');
+    if (row.attachmentWidth !== null)
+      AssertionError.throwNew('invalid approval verdict row: durable width without id');
+    return { ephemeralId: row.ephemeralAttachmentId, durable: null };
+  }
+
+  if (row.attachmentFilename === null)
+    AssertionError.throwNew('invalid approval verdict row: durable attachment missing filename');
+  if (row.attachmentUrl === null)
+    AssertionError.throwNew('invalid approval verdict row: durable attachment missing url');
+
+  return {
+    ephemeralId: row.ephemeralAttachmentId,
+    durable: {
+      id: row.durableAttachmentId.toString(),
+      filename: row.attachmentFilename,
+      contentType: row.attachmentContentType,
+      url: row.attachmentUrl,
+      height: row.attachmentHeight,
+      width: row.attachmentWidth,
+    },
+  };
+}
+
+function createApprovalVerdictThread(row: ApprovalVerdictThreadRow) {
+  if (row.pendingChannelThreadId === null) {
+    if (row.threadPendingChannelThreadId !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan pending thread row');
+    if (row.threadParentMessageId !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan thread parent message');
+    if (row.requestedThreadTitle !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan requested thread title');
+    if (row.approvedPendingChannelThreadId !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan approved thread owner');
+    if (row.approvedThreadTitle !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan approved thread title');
+    if (row.approvedThreadId !== null)
+      AssertionError.throwNew('invalid approval verdict row: orphan approved thread id');
+    return null;
+  }
+
+  if (row.threadPendingChannelThreadId === null)
+    AssertionError.throwNew('invalid approval verdict row: pending thread row missing');
+  if (row.threadPendingChannelThreadId !== row.pendingChannelThreadId)
+    AssertionError.throwNew('invalid approval verdict row: pending thread id mismatch');
+  if (row.requestedThreadTitle === null)
+    AssertionError.throwNew('invalid approval verdict row: requested thread title missing');
+
+  if (row.approvedThreadId === null) {
+    if (row.approvedPendingChannelThreadId !== null)
+      AssertionError.throwNew('invalid approval verdict row: approved owner without thread id');
+    if (row.approvedThreadTitle !== null)
+      AssertionError.throwNew('invalid approval verdict row: approved title without thread id');
+    return {
+      title: row.requestedThreadTitle,
+      threadId: null,
+    };
+  }
+
+  if (row.approvedPendingChannelThreadId === null)
+    AssertionError.throwNew('invalid approval verdict row: approved thread owner missing');
+  if (row.approvedPendingChannelThreadId !== row.pendingChannelThreadId)
+    AssertionError.throwNew('invalid approval verdict row: approved thread owner mismatch');
+  if (row.approvedThreadTitle === null)
+    AssertionError.throwNew('invalid approval verdict row: approved thread title missing');
+
+  return {
+    title: row.approvedThreadTitle,
+    threadId: row.approvedThreadId,
+  };
+}
+
+function createApprovalVerdictConfession(
+  row: FlatApprovalVerdictConfessionRow,
+): ApprovalVerdictConfession {
+  return {
+    disabledAt: row.disabledAt,
+    label: row.label,
+    guildId: row.guildId,
+    channelId: row.channelId,
+    authorId: row.authorId,
+    approvedAt: row.approvedAt,
+    content: row.content,
+    confessionId: row.confessionId,
+    parentMessageId: row.parentMessageId,
+    thread: createApprovalVerdictThread(row),
+    attachment: createApprovalVerdictAttachment(row),
+  };
+}
+
+async function loadApprovalVerdictConfession(tx: Transaction, internalId: bigint) {
+  return await tracer.asyncSpan('load-approval-verdict-confession', async span => {
+    span.setAttribute('confession.internal.id', internalId.toString());
+
+    const lockedConfession = aliasedTable(confession, 'confession');
+    const requestedTitle = aliasedTable(pendingChannelThreadTitle, 'requested_title');
+    const approvedTitle = aliasedTable(pendingChannelThreadTitle, 'approved_title');
+    const approvedThreadForPending = tx
+      .select({
+        approvedPendingChannelThreadId: approvedTitle.pendingChannelThreadId,
+        approvedThreadTitle: approvedTitle.title,
+        approvedThreadId: approvedChannelThread.threadId,
+      })
+      .from(approvedChannelThread)
+      .innerJoin(
+        approvedTitle,
+        eq(
+          approvedChannelThread.pendingChannelThreadTitleConfessionInternalId,
+          approvedTitle.confessionInternalId,
+        ),
+      )
+      .as('approved_thread_for_pending');
+
+    const row = await tx
+      .select({
+        disabledAt: channel.disabledAt,
+        label: channel.label,
+        guildId: channel.guildId,
+        channelId: lockedConfession.channelId,
+        authorId: lockedConfession.authorId,
+        approvedAt: lockedConfession.approvedAt,
+        content: lockedConfession.content,
+        confessionId: lockedConfession.confessionId,
+        parentMessageId: lockedConfession.parentMessageId,
+        ephemeralAttachmentId: ephemeralAttachment.id,
+        durableAttachmentId: durableAttachment.id,
+        attachmentFilename: durableAttachment.filename,
+        attachmentContentType: durableAttachment.contentType,
+        attachmentUrl: durableAttachment.url,
+        attachmentHeight: durableAttachment.height,
+        attachmentWidth: durableAttachment.width,
+        pendingChannelThreadId: requestedTitle.pendingChannelThreadId,
+        requestedThreadTitle: requestedTitle.title,
+        threadPendingChannelThreadId: pendingChannelThread.id,
+        threadParentMessageId: pendingChannelThread.parentMessageId,
+        approvedPendingChannelThreadId: approvedThreadForPending.approvedPendingChannelThreadId,
+        approvedThreadTitle: approvedThreadForPending.approvedThreadTitle,
+        approvedThreadId: approvedThreadForPending.approvedThreadId,
+      })
+      .from(lockedConfession)
+      .innerJoin(channel, eq(lockedConfession.channelId, channel.id))
+      .leftJoin(
+        requestedTitle,
+        eq(lockedConfession.internalId, requestedTitle.confessionInternalId),
+      )
+      .leftJoin(
+        pendingChannelThread,
+        eq(requestedTitle.pendingChannelThreadId, pendingChannelThread.id),
+      )
+      .leftJoin(
+        approvedThreadForPending,
+        eq(
+          requestedTitle.pendingChannelThreadId,
+          approvedThreadForPending.approvedPendingChannelThreadId,
+        ),
+      )
+      .leftJoin(
+        ephemeralAttachment,
+        eq(lockedConfession.internalId, ephemeralAttachment.confessionInternalId),
+      )
+      .leftJoin(
+        durableAttachment,
+        eq(ephemeralAttachment.id, durableAttachment.ephemeralAttachmentId),
+      )
+      .where(eq(lockedConfession.internalId, internalId))
+      .limit(1)
+      .for('update', { of: lockedConfession })
+      .then(assertSingle);
+
+    logger.debug('confession details fetched', {
+      'confession.id': row.confessionId.toString(),
+      label: row.label,
+    });
+
+    return createApprovalVerdictConfession(row);
+  });
+}
+
 /**
  * @throws {InsufficientPermissionsApprovalError}
  * @throws {DisabledChannelConfessError}
@@ -150,86 +426,23 @@ async function submitVerdict(
 
     return await db.transaction(
       async tx => {
-        const result = await tracer.asyncSpan('select-confession-details', async span => {
-          span.setAttribute('confession.internal.id', internalId.toString());
-
-          const lockedConfession = aliasedTable(confession, 'confession');
-          const result = await tx
-            .select({
-              disabledAt: channel.disabledAt,
-              label: channel.label,
-              guildId: channel.guildId,
-              channelId: lockedConfession.channelId,
-              authorId: lockedConfession.authorId,
-              approvedAt: lockedConfession.approvedAt,
-              content: lockedConfession.content,
-              confessionId: lockedConfession.confessionId,
-              parentMessageId: lockedConfession.parentMessageId,
-              ephemeralAttachmentId: ephemeralAttachment.id,
-              durableAttachmentId: durableAttachment.id,
-              attachmentFilename: durableAttachment.filename,
-              attachmentContentType: durableAttachment.contentType,
-              attachmentUrl: durableAttachment.url,
-              attachmentHeight: durableAttachment.height,
-              attachmentWidth: durableAttachment.width,
-              threadTitle: pendingChannelThread.title,
-              threadId: approvedChannelThread.threadId,
-            })
-            .from(lockedConfession)
-            .innerJoin(channel, eq(lockedConfession.channelId, channel.id))
-            .leftJoin(
-              pendingChannelThread,
-              eq(lockedConfession.pendingChannelThreadId, pendingChannelThread.id),
-            )
-            .leftJoin(
-              approvedChannelThread,
-              eq(pendingChannelThread.id, approvedChannelThread.pendingChannelThreadId),
-            )
-            .leftJoin(
-              ephemeralAttachment,
-              eq(lockedConfession.internalId, ephemeralAttachment.confessionInternalId),
-            )
-            .leftJoin(
-              durableAttachment,
-              eq(ephemeralAttachment.id, durableAttachment.ephemeralAttachmentId),
-            )
-            .where(eq(lockedConfession.internalId, internalId))
-            .limit(1)
-            .for('update', { of: lockedConfession })
-            .then(assertSingle);
-
-          logger.debug('confession details fetched', {
-            'confession.id': result.confessionId.toString(),
-            label: result.label,
-          });
-
-          return result;
-        });
+        const result = await loadApprovalVerdictConfession(tx, internalId);
         const { approvedAt, disabledAt, authorId, confessionId, label, content } = result;
 
         let embedAttachment: ApprovalVerdictAttachment | null = null;
-        if (result.ephemeralAttachmentId !== null)
-          if (result.durableAttachmentId === null) {
+        if (result.attachment !== null)
+          if (result.attachment.durable === null) {
             if (isApproved) MissingDurableAttachmentApprovalError.throwNew();
             else
               logger.warn('durable attachment missing for rejected confession', {
-                'attachment.id': result.ephemeralAttachmentId.toString(),
+                'attachment.id': result.attachment.ephemeralId.toString(),
               });
           } else {
-            assert(result.attachmentFilename !== null);
-            assert(result.attachmentUrl !== null);
             logger.debug('attachment fetched', {
-              'attachment.filename': result.attachmentFilename,
+              'attachment.filename': result.attachment.durable.filename,
             });
 
-            embedAttachment = {
-              id: result.durableAttachmentId.toString(),
-              filename: result.attachmentFilename,
-              contentType: result.attachmentContentType,
-              url: result.attachmentUrl,
-              height: result.attachmentHeight,
-              width: result.attachmentWidth,
-            };
+            embedAttachment = result.attachment.durable;
           }
 
         if (disabledAt !== null && disabledAt <= timestamp)
@@ -245,10 +458,14 @@ async function submitVerdict(
           },
         ];
 
-        if (result.threadTitle !== null) {
+        if (result.thread !== null) {
           fields.push({ name: 'Parent Channel', value: `<#${result.channelId}>`, inline: true });
-          if (result.threadId !== null)
-            fields.push({ name: 'Thread Channel', value: `<#${result.threadId}>`, inline: true });
+          if (result.thread.threadId !== null)
+            fields.push({
+              name: 'Thread Channel',
+              value: `<#${result.thread.threadId}>`,
+              inline: true,
+            });
         }
 
         if (result.parentMessageId !== null)
@@ -278,8 +495,8 @@ async function submitVerdict(
             inline: true,
           });
 
-          if (result.threadTitle !== null)
-            fields.push({ name: 'Thread Title', value: result.threadTitle, inline: true });
+          if (result.thread !== null)
+            fields.push({ name: 'Thread Title', value: result.thread.title, inline: true });
 
           // eslint-disable-next-line @typescript-eslint/init-declarations
           let image: EmbedImage | undefined;
@@ -318,8 +535,8 @@ async function submitVerdict(
             inline: true,
           });
 
-          if (result.threadTitle !== null)
-            fields.push({ name: 'Thread Title', value: result.threadTitle, inline: true });
+          if (result.thread !== null)
+            fields.push({ name: 'Thread Title', value: result.thread.title, inline: true });
 
           // eslint-disable-next-line @typescript-eslint/init-declarations
           let image: EmbedImage | undefined;
@@ -373,9 +590,9 @@ export async function handleApproval(
 ): Promise<InteractionResponse> {
   const [key, id, ...rest] = customId.split(':');
   strictEqual(rest.length, 0);
-  assert(typeof id !== 'undefined');
+  if (typeof key === 'undefined') MalformedCustomIdFormat.throwNew(customId);
+  if (typeof id === 'undefined') MalformedCustomIdFormat.throwNew(customId);
   const internalId = BigInt(id);
-  assert(typeof key !== 'undefined');
 
   // eslint-disable-next-line @typescript-eslint/init-declarations
   let isApproved: boolean;

--- a/src/routes/webhook/discord/interaction/approval.ts
+++ b/src/routes/webhook/discord/interaction/approval.ts
@@ -9,6 +9,7 @@ import {
   confession,
   durableAttachment,
   ephemeralAttachment,
+  pendingChannelThread,
 } from '$lib/server/database/models';
 import { ConfessionApprovalEvent } from '$lib/server/inngest/functions/dispatch-approval/schema';
 import type { CreateMessageAttachment } from '$lib/server/models/discord/message';
@@ -167,9 +168,14 @@ async function submitVerdict(
               attachmentUrl: durableAttachment.url,
               attachmentHeight: durableAttachment.height,
               attachmentWidth: durableAttachment.width,
+              threadTitle: pendingChannelThread.title,
             })
             .from(lockedConfession)
             .innerJoin(channel, eq(lockedConfession.channelId, channel.id))
+            .leftJoin(
+              pendingChannelThread,
+              eq(lockedConfession.pendingChannelThreadId, pendingChannelThread.id),
+            )
             .leftJoin(
               ephemeralAttachment,
               eq(lockedConfession.internalId, ephemeralAttachment.confessionInternalId),
@@ -250,6 +256,9 @@ async function submitVerdict(
             inline: true,
           });
 
+          if (result.threadTitle !== null)
+            fields.push({ name: 'Thread Title', value: result.threadTitle, inline: true });
+
           // eslint-disable-next-line @typescript-eslint/init-declarations
           let image: EmbedImage | undefined;
           if (embedAttachment !== null)
@@ -286,6 +295,9 @@ async function submitVerdict(
             value: `<@${moderatorId}>`,
             inline: true,
           });
+
+          if (result.threadTitle !== null)
+            fields.push({ name: 'Thread Title', value: result.threadTitle, inline: true });
 
           // eslint-disable-next-line @typescript-eslint/init-declarations
           let image: EmbedImage | undefined;


### PR DESCRIPTION
This overhauls anonymous thread handling so thread submissions behave like an app-level upsert instead of leaving orphaned persisted confessions when Discord thread creation runs into an already-existing thread. For `Reply as Anonymous Thread`, Spectro now treats Discord's "thread already created for message" response as the existing thread target, records the managed thread mapping, and continues through the normal log/post or approval-dispatch flow.

This closes #42 by ensuring the thread-reply failure mode no longer persists a confession that is neither logged nor published. The same thread machinery now also supports approval-enabled channels, where the Discord thread is intentionally created or resolved later during approval.

## Implementation Notes

### Thread Data Model

- Reworked thread persistence around `pending_channel_thread`, `pending_channel_thread_title`, and `approved_channel_thread`.
- Moved thread titles out of `pending_channel_thread` and into `pending_channel_thread_title`, keyed by confession internal ID, so approval order determines the winning title.
- Connected `approved_channel_thread` to the winning title row instead of storing a duplicated pending-thread pointer.
- Added supporting foreign keys and indexes for the new relationships and future cascade behavior.

### Upsert Thread Resolution

- Added `resolveApprovedChannelThread` as the shared database primitive for idempotently resolving or inserting an approved Discord thread.
- The resolver now:
  - looks up whether the pending thread is already approved,
  - takes an advisory lock on the pending thread before insertion,
  - rechecks state after the lock,
  - falls back to an existing Discord thread row when the thread was already registered,
  - inserts only when no existing approved mapping wins.
- Query rows are post-processed into normalized state before the workflow code consumes them, so handler and Inngest paths do not need to assert impossible database states.

### Submission And Approval Flows

- Updated immediate `/thread` and reply-as-thread submissions to resolve already-created message threads instead of failing with an orphaned confession.
- Allowed approval-gated thread submissions to defer thread creation until approval while keeping the same pending-thread model.
- Updated approval dispatch to create or resolve the Discord thread, then publish into the resolved channel.
- Kept recursive thread creation disallowed at the modal/submission boundary; replying inside an existing thread still uses the normal anonymous message path.

### Query State Normalization

- Collapsed split thread lookups into joined queries where practical.
- Moved database invariant checks into query/state builders for approval dispatch, resend, submission, and verdict handling.
- Removed stale assumptions that thread titles live on `pending_channel_thread`.
- Refactored approval verdict loading so `approval.ts` consumes a shaped verdict object instead of raw nullable database rows.

### Logging And Payloads

- Preserved thread metadata in moderator log payloads.
- Added thread title and thread channel context to approval/rejection logs where available.
- Kept `Reply To` as a Discord message URL because it points to a specific message, while channel and thread fields stay channel-mention formatted.

## Breaking Changes

This changes the thread-related database model. Existing `pending_channel_thread.title` data is migrated into the new title-centric model by the included migrations.

## Test Cases

- [ ] Submit `/thread` in a non-approval channel and confirm the confession is logged and published into the created thread.
- [ ] Submit `Reply as Anonymous Thread` for a message that has no thread and confirm Spectro creates the message thread, logs the confession, and publishes into that thread.
- [ ] Submit `Reply as Anonymous Thread` for a message that already has a Discord thread and confirm Spectro resolves the existing thread instead of leaving an unlogged confession.
- [ ] Submit `/thread` in an approval-enabled channel and confirm the confession is logged as pending without creating the Discord thread immediately.
- [ ] Approve an approval-gated `/thread` confession and confirm the Discord thread is created, registered, and receives the published confession.
- [ ] Approve multiple pending replies for the same parent message out of submission order and confirm the first approved title wins.
- [ ] Submit an anonymous message inside an existing thread and confirm recursive thread creation remains disallowed for thread-creation flows.
